### PR TITLE
Someday filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **Someday Project Filtering**: Tasks belonging to Someday projects are now filtered out of Today, Upcoming, and Anytime views, matching Things UI behavior. The Someday view also includes tasks from Someday projects that Things.py reports as Anytime. Handles both direct project membership and tasks under headings in Someday projects.
+- **Someday Inheritance Display**: Tasks in Someday projects now show `List: Someday (inherited from project)` in formatted output, making the inherited status visible.
+
 ## v0.6.0 - 2026-01-14
 
 - **Creation Date Filtering**: Added `last` parameter to `search_advanced` for filtering by creation date (e.g., '3d' for last 3 days, '1w' for last week)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ This is a Model Context Protocol (MCP) server that bridges Claude Desktop with t
    - CRUD operations for todos/projects/areas
    - Search and tag operations
    - Things URL scheme integration
+   - Implements Someday project filtering to match Things UI behavior
 
 2. **src/things_mcp/url_scheme.py** - Things URL scheme implementation
    - Constructs Things URLs for various operations
@@ -64,12 +65,14 @@ This is a Model Context Protocol (MCP) server that bridges Claude Desktop with t
    - Converts Things database objects to human-readable text
    - Handles nested data (projects within areas, checklist items, etc.)
 
-4. **tests/** - Unit test suite (101 total tests)
+4. **tests/** - Unit test suite
    - **conftest.py** - Pytest fixtures and mock data
    - **test_url_scheme.py** - Tests for URL construction (30 test cases)
-   - **test_formatters.py** - Tests for data formatting (62 test cases)
+   - **test_formatters.py** - Tests for data formatting (67 test cases)
    - **test_things_server.py** - Tests for server tools (5 test cases)
    - **test_things_server_headings.py** - Tests for heading functionality (4 test cases)
+   - **test_someday_filtering.py** - Tests for Someday project filtering (8 test cases)
+   - **test_mcp_server_filtering.py** - Integration tests for MCP server filtering (7 test cases)
 
 ## Key Implementation Details
 
@@ -79,6 +82,7 @@ This is a Model Context Protocol (MCP) server that bridges Claude Desktop with t
 - All tools return formatted text strings suitable for Claude
 - Error handling for invalid UUIDs and missing parameters
 - Supports filtering and including nested items via parameters
+- **Someday Project Filtering**: Tasks from Someday projects are filtered out of Today, Upcoming, and Anytime views to match the Things UI behavior and reduce clutter
 - Unit tests mock all external dependencies (Things.py, shell commands)
 - Pytest configuration in pyproject.toml with async support
 - Supports both stdio (default) and HTTP transport modes

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you find this project helpful, consider supporting its development:
 - Recent items
 - Detailed item information including checklists
 - Support for nested data (projects within areas, todos within projects)
+- Someday project filtering: tasks in Someday projects are automatically excluded from Today, Upcoming, and Anytime views, matching Things UI behavior
 
 
 ## Installation
@@ -104,7 +105,7 @@ After installation:
 - `get-today` - Get todos due today
 - `get-upcoming` - Get upcoming todos
 - `get-anytime` - Get todos from Anytime list
-- `get-someday` - Get todos from Someday list
+- `get-someday` - Get todos from Someday list, including tasks in Someday projects
 - `get-logbook` - Get completed todos
 - `get-trash` - Get trashed todos
 
@@ -215,7 +216,9 @@ things-mcp/
 ├── tests/               # Unit tests
 │   ├── conftest.py      # Test fixtures and configuration
 │   ├── test_url_scheme.py
-│   └── test_formatters.py
+│   ├── test_formatters.py
+│   ├── test_someday_filtering.py
+│   └── test_mcp_server_filtering.py
 ├── docs/                # Documentation
 │   └── mcp_integration_test_plan.md  # Claude-executable integration test
 ├── manifest.json        # MCPB package manifest

--- a/tests/test_mcp_server_filtering.py
+++ b/tests/test_mcp_server_filtering.py
@@ -1,0 +1,150 @@
+"""Integration tests for MCP server functions with Someday filtering."""
+
+import pytest
+from unittest.mock import patch
+
+import things_mcp.server as things_server
+
+
+class TestMCPServerFiltering:
+    """Test that MCP server functions properly filter Someday project tasks."""
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.anytime')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_anytime_filters_someday_tasks(self, mock_projects, mock_anytime):
+        """Test that get_anytime filters out tasks from Someday projects."""
+        mock_anytime.return_value = [
+            {'uuid': 'task-1', 'title': 'Someday task', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-2', 'title': 'Active task', 'project': 'active-proj', 'type': 'to-do'},
+            {'uuid': 'task-3', 'title': 'No project', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj', 'title': 'Someday Project'}
+        ]
+
+        result = await things_server.get_anytime.fn()
+
+        # Should only include task-2 and task-3
+        assert 'task-1' not in result
+        assert 'Active task' in result
+        assert 'No project' in result
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.today')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_today_filters_someday_tasks(self, mock_projects, mock_today):
+        """Test that get_today filters out tasks from Someday projects."""
+        mock_today.return_value = [
+            {'uuid': 'task-4', 'title': 'Today someday task', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-5', 'title': 'Today active task', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        result = await things_server.get_today.fn()
+
+        # Should only include task-5
+        assert 'Today someday task' not in result
+        assert 'Today active task' in result
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.upcoming')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_upcoming_filters_someday_tasks(self, mock_projects, mock_upcoming):
+        """Test that get_upcoming filters out tasks from Someday projects."""
+        mock_upcoming.return_value = [
+            {'uuid': 'task-6', 'title': 'Upcoming someday', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-7', 'title': 'Upcoming active', 'project': 'active-proj', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        result = await things_server.get_upcoming.fn()
+
+        # Should only include task-7
+        assert 'Upcoming someday' not in result
+        assert 'Upcoming active' in result
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.anytime')
+    async def test_get_anytime_handles_empty_list(self, mock_anytime):
+        """Test that get_anytime handles empty results gracefully."""
+        mock_anytime.return_value = []
+
+        result = await things_server.get_anytime.fn()
+
+        assert result == "No items found"
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.anytime')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_anytime_all_filtered_returns_empty(self, mock_projects, mock_anytime):
+        """Test that get_anytime returns 'No items found' when all tasks are filtered."""
+        mock_anytime.return_value = [
+            {'uuid': 'task-1', 'title': 'Someday 1', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-2', 'title': 'Someday 2', 'project': 'someday-proj', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        result = await things_server.get_anytime.fn()
+
+        assert result == "No items found"
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.anytime')
+    @patch('things_mcp.server.things.someday')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_someday_includes_tasks_from_someday_projects(self, mock_projects, mock_someday, mock_anytime):
+        """Test that get_someday includes tasks from Someday projects even if their start is Anytime."""
+        mock_someday.return_value = [
+            {'uuid': 'task-1', 'title': 'Explicitly someday', 'type': 'to-do'},
+        ]
+
+        mock_anytime.return_value = [
+            {'uuid': 'task-2', 'title': 'In someday project', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-3', 'title': 'In active project', 'project': 'active-proj', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        result = await things_server.get_someday.fn()
+
+        assert 'Explicitly someday' in result
+        assert 'In someday project' in result
+        assert 'In active project' not in result
+
+    @pytest.mark.asyncio
+    @patch('things_mcp.server.things.anytime')
+    @patch('things_mcp.server.things.someday')
+    @patch('things_mcp.server.things.projects')
+    async def test_get_someday_no_duplicates(self, mock_projects, mock_someday, mock_anytime):
+        """Test that get_someday doesn't duplicate tasks already in the someday list."""
+        mock_someday.return_value = [
+            {'uuid': 'task-1', 'title': 'Already someday', 'project': 'someday-proj', 'type': 'to-do'},
+        ]
+
+        mock_anytime.return_value = [
+            {'uuid': 'task-1', 'title': 'Already someday', 'project': 'someday-proj', 'type': 'to-do'},
+            {'uuid': 'task-2', 'title': 'Another someday proj task', 'project': 'someday-proj', 'type': 'to-do'},
+        ]
+
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        result = await things_server.get_someday.fn()
+
+        # task-1 should appear only once
+        assert result.count('Already someday') == 1
+        assert 'Another someday proj task' in result

--- a/tests/test_someday_filtering.py
+++ b/tests/test_someday_filtering.py
@@ -1,0 +1,166 @@
+"""Tests for filtering tasks from Someday projects."""
+
+import pytest
+from unittest.mock import patch
+
+from things_mcp.server import filter_someday_project_tasks
+
+
+class TestSomedayFiltering:
+    """Test suite for filtering tasks from Someday projects."""
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_removes_someday_project_tasks(self, mock_projects):
+        """Test that tasks from Someday projects are filtered out."""
+        mock_projects.return_value = [
+            {'uuid': 'project-123', 'title': 'Someday Project', 'status': 'someday'}
+        ]
+
+        todos = [
+            {
+                'uuid': 'task-1',
+                'title': 'Task in Someday project',
+                'project': 'project-123',
+                'status': 'incomplete'
+            }
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 0
+        mock_projects.assert_called_once_with(start='Someday')
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_keeps_active_project_tasks(self, mock_projects):
+        """Test that tasks from active projects are kept."""
+        # No someday projects
+        mock_projects.return_value = []
+
+        todos = [
+            {
+                'uuid': 'task-2',
+                'title': 'Task in active project',
+                'project': 'project-456',
+                'status': 'incomplete'
+            }
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 1
+        assert result[0]['uuid'] == 'task-2'
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_keeps_tasks_without_project(self, mock_projects):
+        """Test that tasks without a project are kept."""
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        todos = [
+            {
+                'uuid': 'task-3',
+                'title': 'Standalone task',
+                'status': 'incomplete'
+            }
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 1
+        assert result[0]['uuid'] == 'task-3'
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_mixed_tasks(self, mock_projects):
+        """Test filtering with a mix of task types."""
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+
+        todos = [
+            {'uuid': 'task-1', 'title': 'Someday task', 'project': 'someday-proj'},
+            {'uuid': 'task-2', 'title': 'Active task', 'project': 'active-proj'},
+            {'uuid': 'task-3', 'title': 'No project task'},
+            {'uuid': 'task-4', 'title': 'Another someday', 'project': 'someday-proj'},
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 2
+        assert result[0]['uuid'] == 'task-2'
+        assert result[1]['uuid'] == 'task-3'
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_handles_exception(self, mock_projects):
+        """Test that exceptions during project lookup don't crash the filter."""
+        mock_projects.side_effect = Exception("Database error")
+
+        todos = [
+            {
+                'uuid': 'task-error',
+                'title': 'Task that causes error',
+                'project': 'error-project'
+            }
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        # Should return all todos when query fails
+        assert len(result) == 1
+        assert result[0]['uuid'] == 'task-error'
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_empty_list(self, mock_projects):
+        """Test filtering an empty list."""
+        mock_projects.return_value = []
+        result = filter_someday_project_tasks([])
+        assert result == []
+
+    @patch('things_mcp.server.things.projects')
+    def test_filter_preserves_task_data(self, mock_projects):
+        """Test that filtering preserves all task fields."""
+        mock_projects.return_value = []
+
+        todos = [
+            {
+                'uuid': 'task-full',
+                'title': 'Full task',
+                'project': 'active-proj',
+                'notes': 'Some notes',
+                'tags': ['tag1', 'tag2'],
+                'deadline': '2025-12-31',
+                'status': 'incomplete'
+            }
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 1
+        # Verify all fields are preserved
+        assert result[0]['uuid'] == 'task-full'
+        assert result[0]['title'] == 'Full task'
+        assert result[0]['notes'] == 'Some notes'
+        assert result[0]['tags'] == ['tag1', 'tag2']
+        assert result[0]['deadline'] == '2025-12-31'
+
+    @patch('things_mcp.server.things.tasks')
+    @patch('things_mcp.server.things.projects')
+    def test_filter_removes_heading_tasks_in_someday_project(self, mock_projects, mock_tasks):
+        """Test that tasks under a heading in a Someday project are filtered out."""
+        mock_projects.return_value = [
+            {'uuid': 'someday-proj'}
+        ]
+        mock_tasks.return_value = [
+            {'uuid': 'heading-1', 'project': 'someday-proj'}
+        ]
+
+        todos = [
+            {'uuid': 'task-1', 'title': 'Direct project task', 'project': 'someday-proj'},
+            {'uuid': 'task-2', 'title': 'Heading task', 'heading': 'heading-1'},
+            {'uuid': 'task-3', 'title': 'Unrelated task'},
+        ]
+
+        result = filter_someday_project_tasks(todos)
+
+        assert len(result) == 1
+        assert result[0]['uuid'] == 'task-3'

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Summary                                                                                                              
                                                                                                                       
  - Filter tasks from Someday projects out of Today, Upcoming, and Anytime views to match Things UI behavior
  - Include tasks from Someday projects in the Someday view (Things.py reports them as Anytime)
  - Handle both direct project membership and tasks under headings in Someday projects
  - Show List: Someday (inherited from project) in formatted output for inherited status

  Background

  Things.py doesn't inherit a project's Someday status down to its tasks — it reports them with start=Anytime. This
  means get_today, get_upcoming, and get_anytime return tasks that the Things UI hides, and get_someday misses tasks
  that the Things UI shows.

  Changes

  - server.py: Added filter_someday_project_tasks() and helpers; applied to get_today, get_upcoming, get_anytime;
  rewrote get_someday to pull in Someday project tasks
  - formatters.py: Added parent project lookup (including heading→project chain) for Someday inheritance display
  - tests: 15 new tests (8 unit + 7 integration) covering filtering logic and tool endpoints, plus 5 new formatter
  tests
  - README.md / CHANGELOG.md: Documented the feature

  Test plan

  - uv run pytest -v — 121 tests passing (101 existing + 20 new)
  - Manual verification with a Things database containing Someday projects
