### PR TITLE
Add response pagination to Things read tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you find this project helpful, consider supporting its development:
 - Detailed item information including checklists
 - Support for nested data (projects within areas, todos within projects)
 - Someday project filtering: tasks in Someday projects are automatically excluded from Today, Upcoming, and Anytime views, matching Things UI behavior
+- Optional `limit` and `offset` pagination for read/query tools to keep MCP responses manageable
 
 
 ## Installation
@@ -134,6 +135,16 @@ After installation:
 - `search-items` - Search for items in Things
 
 ## Tool Parameters
+
+### Pagination for Read Tools
+- Most read-only tools support `limit` and `offset`
+- `limit` (optional) - Maximum number of items to return. Must be positive. If omitted, returns all matching items
+- `offset` (optional, default: `0`) - Number of matching items to skip before returning results
+- Pagination is applied after filtering and before formatting
+- Paginated responses include a `Showing X-Y of Z items` header
+
+This applies to list views, data query tools, tag tools, search tools, and `get-recent`.
+`get-logbook` also supports `offset` and keeps its default `limit` of `50`.
 
 ### get-todos
 - `project_uuid` (optional) - Filter todos by project

--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -83,6 +83,9 @@ def _validate_pagination(limit: int | None, offset: int) -> str | None:
     return None
 
 
+# Pagination in this server is applied after fetching from things.py.
+# It is meant to bound MCP response size and support follow-up scans, not to
+# reduce the number of rows read from the Things data source.
 def _format_paginated_results(
     items: list[dict],
     formatter: Callable[[dict], str],
@@ -90,7 +93,14 @@ def _format_paginated_results(
     limit: int | None = None,
     offset: int = 0,
 ) -> str:
-    """Apply limit/offset pagination and format a collection for MCP output."""
+    """Apply local response pagination and format a collection for MCP output.
+
+    Notes:
+        This slices an already-fetched collection. It does not push limit/offset
+        down into things.py, since the read APIs used by this server do not
+        expose pagination primitives. The goal is to keep MCP responses smaller
+        and make multi-turn scans easier for downstream agents.
+    """
     if not items:
         return empty_message
 

--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 import logging
 import os
 import things
@@ -74,61 +74,120 @@ def filter_someday_project_tasks(todos):
     return [todo for todo in todos if not _is_in_someday_project(todo, someday_project_ids, heading_to_project)]
 
 
+def _validate_pagination(limit: int | None, offset: int) -> str | None:
+    """Validate pagination inputs shared by read/query tools."""
+    if limit is not None and limit <= 0:
+        return "Error: limit must be a positive integer"
+    if offset < 0:
+        return "Error: offset must be a non-negative integer"
+    return None
+
+
+def _format_paginated_results(
+    items: list[dict],
+    formatter: Callable[[dict], str],
+    empty_message: str,
+    limit: int | None = None,
+    offset: int = 0,
+) -> str:
+    """Apply limit/offset pagination and format a collection for MCP output."""
+    end = None if limit is None else offset + limit
+    paginated_items = items[offset:end]
+    if not paginated_items:
+        return empty_message
+
+    formatted_items = [formatter(item) for item in paginated_items]
+    result = "\n\n---\n\n".join(formatted_items)
+
+    if limit is None and offset == 0:
+        return result
+
+    start_index = offset + 1
+    end_index = offset + len(paginated_items)
+    item_label = "item" if len(items) == 1 else "items"
+    return f"Showing {start_index}-{end_index} of {len(items)} {item_label}\n\n{result}"
+
+
 # List view tools
 @mcp.tool
-async def get_inbox() -> str:
-    """Get todos from Inbox"""
-    todos = things.inbox(include_items=True)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+async def get_inbox(limit: int | None = None, offset: int = 0) -> str:
+    """Get todos from Inbox
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.inbox(include_items=True) or []
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_today() -> str:
-    """Get todos due today"""
-    todos = things.today(include_items=True)
-    if not todos:
-        return "No items found"
+async def get_today(limit: int | None = None, offset: int = 0) -> str:
+    """Get todos due today
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.today(include_items=True) or []
     # Filter out tasks from Someday projects
     todos = filter_someday_project_tasks(todos)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_upcoming() -> str:
-    """Get upcoming todos"""
-    todos = things.upcoming(include_items=True)
-    if not todos:
-        return "No items found"
+async def get_upcoming(limit: int | None = None, offset: int = 0) -> str:
+    """Get upcoming todos
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.upcoming(include_items=True) or []
     # Filter out tasks from Someday projects
     todos = filter_someday_project_tasks(todos)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_anytime() -> str:
-    """Get todos from Anytime list"""
-    todos = things.anytime(include_items=True)
-    if not todos:
-        return "No items found"
+async def get_anytime(limit: int | None = None, offset: int = 0) -> str:
+    """Get todos from Anytime list
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.anytime(include_items=True) or []
     # Filter out tasks from Someday projects
     todos = filter_someday_project_tasks(todos)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_someday() -> str:
-    """Get todos from Someday list, including tasks in Someday projects"""
-    todos = things.someday(include_items=True)
-    if todos is None:
-        todos = []
+async def get_someday(limit: int | None = None, offset: int = 0) -> str:
+    """Get todos from Someday list, including tasks in Someday projects
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.someday(include_items=True) or []
     # Also include tasks that have start="Anytime" but belong to a Someday project
     # (directly or via a heading), since Things.py doesn't inherit project Someday status
     someday_project_ids, heading_to_project = _get_someday_context()
@@ -138,121 +197,163 @@ async def get_someday() -> str:
         for todo in anytime_todos:
             if _is_in_someday_project(todo, someday_project_ids, heading_to_project) and todo['uuid'] not in existing_uuids:
                 todos.append(todo)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_logbook(period: str = "7d", limit: int = 50) -> str:
+async def get_logbook(period: str = "7d", limit: int | None = 50, offset: int = 0) -> str:
     """Get completed todos from Logbook, defaults to last 7 days
 
     Args:
         period: Time period to look back (e.g., '3d', '1w', '2m', '1y'). Defaults to '7d'
-        limit: Maximum number of entries to return. Defaults to 50
+        limit: Maximum number of items to return. Defaults to 50.
+        offset: Number of items to skip before returning results.
     """
-    todos = things.last(period, status='completed', include_items=True)
-    if todos and len(todos) > limit:
-        todos = todos[:limit]
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.last(period, status='completed', include_items=True) or []
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 @mcp.tool
-async def get_trash() -> str:
-    """Get trashed todos"""
-    todos = things.trash(include_items=True)
-    if not todos:
-        return "No items found"
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+async def get_trash(limit: int | None = None, offset: int = 0) -> str:
+    """Get trashed todos
+
+    Args:
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
+    """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
+    todos = things.trash(include_items=True) or []
+    return _format_paginated_results(todos, format_todo, "No items found", limit, offset)
 
 # Basic operations
 @mcp.tool
-async def get_todos(project_uuid: str = None, include_items: bool = True) -> str:
+async def get_todos(
+    project_uuid: str = None,
+    include_items: bool = True,
+    limit: int | None = None,
+    offset: int = 0
+) -> str:
     """Get todos from Things, optionally filtered by project
 
     Args:
         project_uuid: Optional UUID of a specific project to get todos from
         include_items: Include checklist items
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
     if project_uuid:
         project = things.get(project_uuid)
         if not project or project.get('type') != 'project':
             return f"Error: Invalid project UUID '{project_uuid}'"
 
-    todos = things.todos(project=project_uuid, start=None, include_items=include_items)
-    if not todos:
-        return "No todos found"
-
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    todos = things.todos(project=project_uuid, start=None, include_items=include_items) or []
+    return _format_paginated_results(todos, format_todo, "No todos found", limit, offset)
 
 @mcp.tool
-async def get_projects(include_items: bool = False) -> str:
+async def get_projects(include_items: bool = False, limit: int | None = None, offset: int = 0) -> str:
     """Get all projects from Things
 
     Args:
         include_items: Include tasks within projects
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    projects = things.projects()
-    if not projects:
-        return "No projects found"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_projects = [format_project(project, include_items) for project in projects]
-    return "\n\n---\n\n".join(formatted_projects)
+    projects = things.projects() or []
+    return _format_paginated_results(
+        projects,
+        lambda project: format_project(project, include_items),
+        "No projects found",
+        limit,
+        offset,
+    )
 
 @mcp.tool
-async def get_areas(include_items: bool = False) -> str:
+async def get_areas(include_items: bool = False, limit: int | None = None, offset: int = 0) -> str:
     """Get all areas from Things
 
     Args:
         include_items: Include projects and tasks within areas
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    areas = things.areas()
-    if not areas:
-        return "No areas found"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_areas = [format_area(area, include_items) for area in areas]
-    return "\n\n---\n\n".join(formatted_areas)
+    areas = things.areas() or []
+    return _format_paginated_results(
+        areas,
+        lambda area: format_area(area, include_items),
+        "No areas found",
+        limit,
+        offset,
+    )
 
 # Tag operations
 @mcp.tool
-async def get_tags(include_items: bool = False) -> str:
+async def get_tags(include_items: bool = False, limit: int | None = None, offset: int = 0) -> str:
     """Get all tags
 
     Args:
         include_items: Include items tagged with each tag
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    tags = things.tags()
-    if not tags:
-        return "No tags found"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_tags = [format_tag(tag, include_items) for tag in tags]
-    return "\n\n---\n\n".join(formatted_tags)
+    tags = things.tags() or []
+    return _format_paginated_results(
+        tags,
+        lambda tag: format_tag(tag, include_items),
+        "No tags found",
+        limit,
+        offset,
+    )
 
 @mcp.tool
-async def get_tagged_items(tag: str) -> str:
+async def get_tagged_items(tag: str, limit: int | None = None, offset: int = 0) -> str:
     """Get items with a specific tag
 
     Args:
         tag: Tag title to filter by
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    todos = things.todos(tag=tag, include_items=True)
-    if not todos:
-        return f"No items found with tag '{tag}'"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    todos = things.todos(tag=tag, include_items=True) or []
+    return _format_paginated_results(todos, format_todo, f"No items found with tag '{tag}'", limit, offset)
 
 @mcp.tool
-async def get_headings(project_uuid: str = None) -> str:
+async def get_headings(project_uuid: str = None, limit: int | None = None, offset: int = 0) -> str:
     """Get headings from Things
 
     Args:
         project_uuid: Optional UUID of a specific project to get headings from
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
     if project_uuid:
         project = things.get(project_uuid)
         if not project or project.get('type') != 'project':
@@ -261,26 +362,24 @@ async def get_headings(project_uuid: str = None) -> str:
     else:
         headings = things.tasks(type='heading')
 
-    if not headings:
-        return "No headings found"
-
-    formatted_headings = [format_heading(heading) for heading in headings]
-    return "\n\n---\n\n".join(formatted_headings)
+    return _format_paginated_results(headings or [], format_heading, "No headings found", limit, offset)
 
 # Search operations
 @mcp.tool
-async def search_todos(query: str) -> str:
+async def search_todos(query: str, limit: int | None = None, offset: int = 0) -> str:
     """Search todos by title or notes
 
     Args:
         query: Search term to look for in todo titles and notes
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    todos = things.search(query, include_items=True)
-    if not todos:
-        return f"No todos found matching '{query}'"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    todos = things.search(query, include_items=True) or []
+    return _format_paginated_results(todos, format_todo, f"No todos found matching '{query}'", limit, offset)
 
 @mcp.tool
 async def search_advanced(
@@ -290,7 +389,9 @@ async def search_advanced(
     tag: str = None,
     area: str = None,
     type: str = None,
-    last: str = None
+    last: str = None,
+    limit: int | None = None,
+    offset: int = 0
 ) -> str:
     """Advanced todo search with multiple filters
 
@@ -302,7 +403,13 @@ async def search_advanced(
         area: Filter by area UUID
         type: Filter by item type (to-do, project, heading)
         last: Filter by creation date (e.g., '3d' for last 3 days, '1w' for last week, '1y' for last year)
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
+
     search_params = {}
     if status:
         search_params["status"] = status
@@ -323,26 +430,24 @@ async def search_advanced(
         todos = things.tasks(type=type, include_items=True, **search_params)
     else:
         todos = things.todos(include_items=True, **search_params)
-    if not todos:
-        return "No matching todos found"
-
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    return _format_paginated_results(todos or [], format_todo, "No matching todos found", limit, offset)
 
 # Recent items
 @mcp.tool
-async def get_recent(period: str) -> str:
+async def get_recent(period: str, limit: int | None = None, offset: int = 0) -> str:
     """Get recently created items
 
     Args:
         period: Time period (e.g., '3d', '1w', '2m', '1y')
+        limit: Maximum number of items to return. Omit to return all items.
+        offset: Number of items to skip before returning results.
     """
-    todos = things.last(period, include_items=True)
-    if not todos:
-        return f"No items found in the last {period}"
+    pagination_error = _validate_pagination(limit, offset)
+    if pagination_error:
+        return pagination_error
 
-    formatted_todos = [format_todo(todo) for todo in todos]
-    return "\n\n---\n\n".join(formatted_todos)
+    todos = things.last(period, include_items=True) or []
+    return _format_paginated_results(todos, format_todo, f"No items found in the last {period}", limit, offset)
 
 # Things URL Scheme tools
 @mcp.tool

--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -91,10 +91,15 @@ def _format_paginated_results(
     offset: int = 0,
 ) -> str:
     """Apply limit/offset pagination and format a collection for MCP output."""
+    if not items:
+        return empty_message
+
     end = None if limit is None else offset + limit
     paginated_items = items[offset:end]
+    item_label = "item" if len(items) == 1 else "items"
+
     if not paginated_items:
-        return empty_message
+        return f"Showing 0 of {len(items)} {item_label} (offset {offset} is past the end)"
 
     formatted_items = [formatter(item) for item in paginated_items]
     result = "\n\n---\n\n".join(formatted_items)
@@ -104,7 +109,6 @@ def _format_paginated_results(
 
     start_index = offset + 1
     end_index = offset + len(paginated_items)
-    item_label = "item" if len(items) == 1 else "items"
     return f"Showing {start_index}-{end_index} of {len(items)} {item_label}\n\n{result}"
 
 

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -44,6 +44,19 @@ async def test_get_todos_rejects_non_positive_limit(mocker):
 
 
 @pytest.mark.asyncio
+async def test_get_todos_offset_past_end_reports_empty_page(mocker):
+    mock_things_todos = mocker.patch('things.todos')
+    mock_things_todos.return_value = [
+        {'uuid': 'task-1', 'title': 'First Task', 'type': 'to-do'},
+        {'uuid': 'task-2', 'title': 'Second Task', 'type': 'to-do'},
+    ]
+
+    result = await get_todos.fn(limit=10, offset=10)
+
+    assert result == "Showing 0 of 2 items (offset 10 is past the end)"
+
+
+@pytest.mark.asyncio
 async def test_get_today_includes_checklist(mocker, mock_todo, mock_things_get):
     mock_today = mocker.patch('things.today')
     mock_projects = mocker.patch('things_mcp.server.things.projects')

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,23 +1,54 @@
 import pytest
-from things_mcp.server import get_todos, get_today, search_todos, search_advanced
+from things_mcp.server import get_logbook, get_today, get_todos, search_todos, search_advanced
 
 
 @pytest.mark.asyncio
-async def test_get_todos_includes_checklist(mocker, mock_todo):
+async def test_get_todos_includes_checklist(mocker, mock_todo, mock_things_get):
     mock_things_todos = mocker.patch('things.todos')
     mock_things_todos.return_value = [mock_todo]
 
     result = await get_todos.fn(include_items=True)
 
+    assert "Showing " not in result
     assert "Checklist:" in result
     assert "First item" in result
     mock_things_todos.assert_called_once_with(project=None, start=None, include_items=True)
 
 
 @pytest.mark.asyncio
-async def test_get_today_includes_checklist(mocker, mock_todo):
+async def test_get_todos_applies_limit_and_offset(mocker):
+    mock_things_todos = mocker.patch('things.todos')
+    mock_things_todos.return_value = [
+        {'uuid': 'task-1', 'title': 'First Task', 'type': 'to-do'},
+        {'uuid': 'task-2', 'title': 'Second Task', 'type': 'to-do'},
+        {'uuid': 'task-3', 'title': 'Third Task', 'type': 'to-do'},
+    ]
+
+    result = await get_todos.fn(limit=1, offset=1)
+
+    assert "Showing 2-2 of 3 items" in result
+    assert "Second Task" in result
+    assert "First Task" not in result
+    assert "Third Task" not in result
+    mock_things_todos.assert_called_once_with(project=None, start=None, include_items=True)
+
+
+@pytest.mark.asyncio
+async def test_get_todos_rejects_non_positive_limit(mocker):
+    mock_things_todos = mocker.patch('things.todos')
+
+    result = await get_todos.fn(limit=0)
+
+    assert result == "Error: limit must be a positive integer"
+    mock_things_todos.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_today_includes_checklist(mocker, mock_todo, mock_things_get):
     mock_today = mocker.patch('things.today')
+    mock_projects = mocker.patch('things_mcp.server.things.projects')
     mock_today.return_value = [mock_todo]
+    mock_projects.return_value = []
 
     result = await get_today.fn()
 
@@ -27,7 +58,29 @@ async def test_get_today_includes_checklist(mocker, mock_todo):
 
 
 @pytest.mark.asyncio
-async def test_search_todos_includes_checklist(mocker, mock_todo):
+async def test_get_today_paginates_after_someday_filtering(mocker):
+    mock_today = mocker.patch('things.today')
+    mock_projects = mocker.patch('things_mcp.server.things.projects')
+    mock_tasks = mocker.patch('things_mcp.server.things.tasks')
+
+    mock_today.return_value = [
+        {'uuid': 'task-1', 'title': 'Someday Task', 'type': 'to-do', 'project': 'someday-proj'},
+        {'uuid': 'task-2', 'title': 'Active Task A', 'type': 'to-do'},
+        {'uuid': 'task-3', 'title': 'Active Task B', 'type': 'to-do'},
+    ]
+    mock_projects.return_value = [{'uuid': 'someday-proj'}]
+    mock_tasks.return_value = []
+
+    result = await get_today.fn(limit=1, offset=1)
+
+    assert "Showing 2-2 of 2 items" in result
+    assert "Active Task B" in result
+    assert "Someday Task" not in result
+    assert "Active Task A" not in result
+
+
+@pytest.mark.asyncio
+async def test_search_todos_includes_checklist(mocker, mock_todo, mock_things_get):
     mock_search = mocker.patch('things.search')
     mock_search.return_value = [mock_todo]
 
@@ -39,7 +92,26 @@ async def test_search_todos_includes_checklist(mocker, mock_todo):
 
 
 @pytest.mark.asyncio
-async def test_search_advanced_with_type_project(mocker, mock_project):
+async def test_search_advanced_paginates_without_passing_pagination_to_things(mocker):
+    """Test search_advanced paginates locally after querying Things."""
+    mock_things_todos = mocker.patch('things.todos')
+    mock_things_todos.return_value = [
+        {'uuid': 'task-1', 'title': 'First Match', 'type': 'to-do'},
+        {'uuid': 'task-2', 'title': 'Second Match', 'type': 'to-do'},
+    ]
+
+    result = await search_advanced.fn(status="incomplete", limit=1, offset=1)
+
+    mock_things_todos.assert_called_once_with(
+        include_items=True, status="incomplete"
+    )
+    assert "Showing 2-2 of 2 items" in result
+    assert "Second Match" in result
+    assert "First Match" not in result
+
+
+@pytest.mark.asyncio
+async def test_search_advanced_with_type_project(mocker, mock_project, mock_things_get):
     """Test search_advanced with type='project' uses things.tasks()."""
     mock_things_tasks = mocker.patch('things.tasks')
     mock_things_tasks.return_value = [mock_project]
@@ -54,7 +126,7 @@ async def test_search_advanced_with_type_project(mocker, mock_project):
 
 
 @pytest.mark.asyncio
-async def test_search_advanced_without_type(mocker, mock_todo):
+async def test_search_advanced_without_type(mocker, mock_todo, mock_things_get):
     """Test search_advanced without type still uses things.todos()."""
     mock_things_todos = mocker.patch('things.todos')
     mock_things_todos.return_value = [mock_todo]
@@ -66,3 +138,21 @@ async def test_search_advanced_without_type(mocker, mock_todo):
         include_items=True, status="incomplete"
     )
     assert "Test Todo" in result
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_supports_offset(mocker):
+    mock_last = mocker.patch('things.last')
+    mock_last.return_value = [
+        {'uuid': 'task-1', 'title': 'Completed A', 'type': 'to-do'},
+        {'uuid': 'task-2', 'title': 'Completed B', 'type': 'to-do'},
+        {'uuid': 'task-3', 'title': 'Completed C', 'type': 'to-do'},
+    ]
+
+    result = await get_logbook.fn(limit=1, offset=1)
+
+    mock_last.assert_called_once_with("7d", status='completed', include_items=True)
+    assert "Showing 2-2 of 3 items" in result
+    assert "Completed B" in result
+    assert "Completed A" not in result
+    assert "Completed C" not in result


### PR DESCRIPTION
## What changed

This updates the read/query side of the Things MCP server to support local `limit` and `offset` pagination across the high-volume tools.

It also fixes the pagination helper so an out-of-range page is reported distinctly from a truly empty query result, and clarifies in code that pagination is applied after fetching from `things.py`.

## Why this changed

Large Things lists and searches can return a lot of formatted text, which is expensive in MCP/LLM workflows and makes follow-up scans awkward.

The new pagination parameters make it easier to inspect long result sets in smaller chunks while keeping the existing default behavior unchanged when no pagination parameters are provided.

## Impact

- Adds optional `limit` and `offset` parameters to the read/query tools.
- Adds pagination metadata to paginated responses so callers can continue scanning.
- Preserves the previous full-response behavior when pagination is not requested.
- Avoids conflating "no matching items" with "requested page is past the end".
