### PR TITLE
Add area + heading creation tools (AppleScript / UI scripting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - **Add Area Creation**: New `add-area` tool creates Areas in Things 3. Since the Things URL scheme has no `add-area` command, this uses AppleScript (`make new area with properties {name:...}`) and returns the new Area's UUID. Title strings are escaped to prevent AppleScript injection.
+- **Add Heading Creation**: New `add-heading` tool creates Headings inside existing Projects. Things 3 exposes no native AppleScript class for headings and its URL scheme cannot create standalone headings in an existing project, so this drives the Things UI via System Events (`File > New Heading`), types the title, and diffs the heading list before/after to recover the new UUID. Requires Accessibility permission and briefly brings Things 3 to the foreground. Raises a clear error if the UI flow completes without producing a matching heading.
 
 ## v0.7.3 - 2026-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Add Area Creation**: New `add-area` tool creates Areas in Things 3. Since the Things URL scheme has no `add-area` command, this uses AppleScript (`make new area with properties {name:...}`) and returns the new Area's UUID. Title strings are escaped to prevent AppleScript injection.
+
 ## v0.7.3 - 2026-02-13
 
 - **Someday Project Filtering**: Tasks belonging to Someday projects are now filtered out of Today, Upcoming, and Anytime views, matching Things UI behavior. The Someday view also includes tasks from Someday projects that Things.py reports as Anytime. Handles both direct project membership and tasks under headings in Someday projects.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ After installation:
 ### Things URL Scheme Operations
 - `add-todo` - Create a new todo
 - `add-project` - Create a new project
+- `add-area` - Create a new Area (via AppleScript; Things URL scheme has no add-area command)
 - `update-todo` - Update an existing todo
 - `update-project` - Update an existing project
 - `show-item` - Show a specific item or list in Things

--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -389,6 +389,20 @@ async def add_todo(
     return f"Created new todo: {title}"
 
 @mcp.tool
+async def add_area(title: str) -> str:
+    """Create a new Area in Things 3
+
+    Areas are top-level containers in Things 3 (e.g. "Work", "Personal", "Backlog").
+    The Things URL scheme cannot create Areas, so this uses AppleScript.
+
+    Args:
+        title: Title of the area
+    """
+    area_id = url_scheme.add_area(title=title)
+    return f"Created new area: {title} (id: {area_id})"
+
+
+@mcp.tool
 async def add_project(
     title: str,
     notes: str = None,

--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -403,6 +403,23 @@ async def add_area(title: str) -> str:
 
 
 @mcp.tool
+async def add_heading(title: str, project_id: str) -> str:
+    """Create a new Heading inside an existing Project in Things 3.
+
+    Things 3 has no native AppleScript class for headings and its URL scheme
+    cannot create standalone headings in an existing project, so this drives
+    the Things UI via System Events (File > New Heading). Requires
+    Accessibility permission and will briefly bring Things 3 to the foreground.
+
+    Args:
+        title: Title of the heading
+        project_id: UUID of the project to add the heading to
+    """
+    heading_id = url_scheme.add_heading(title=title, project_id=project_id)
+    return f"Created new heading: {title} (id: {heading_id})"
+
+
+@mcp.tool
 async def add_project(
     title: str,
     notes: str = None,

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -40,6 +40,26 @@ def execute_url(url: str) -> None:
         # Fallback - still try with open -g directly
         subprocess.run(['open', '-g', url], check=True)
 
+
+def add_area(title: str) -> str:
+    """Create a new Area in Things 3 via AppleScript.
+
+    The Things URL scheme has no add-area command, so we use AppleScript instead.
+    Returns the new Area's UUID.
+    """
+    escaped_title = title.replace('\\', '\\\\').replace('"', '\\"')
+    applescript = (
+        'tell application "Things3"\n'
+        f'  set newArea to make new area with properties {{name:"{escaped_title}"}}\n'
+        '  return id of newArea\n'
+        'end tell'
+    )
+    result = subprocess.run(
+        ['osascript', '-e', applescript],
+        check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
 def construct_url(command: str, params: Dict[str, Any]) -> str:
     """Construct a Things URL from command and parameters."""
     # Start with base URL

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -60,6 +60,59 @@ def add_area(title: str) -> str:
     )
     return result.stdout.strip()
 
+
+def add_heading(title: str, project_id: str) -> str:
+    """Create a new Heading inside an existing Project via UI scripting.
+
+    Things 3 exposes no native AppleScript class for headings and the URL
+    scheme cannot create standalone headings in an existing project, so we
+    drive the Things UI via System Events:
+
+      1. Navigate to the target project via the URL scheme.
+      2. Invoke File > New Heading from the menu.
+      3. Type the heading title and press Return.
+      4. Diff the heading list before/after to recover the new UUID.
+
+    Requires Accessibility permission for the calling process (System Events)
+    and momentarily brings Things 3 to the foreground.
+
+    Returns the new heading's UUID.
+    """
+    before = {h['uuid'] for h in (things.tasks(type='heading', project=project_id) or [])}
+
+    escaped_title = title.replace('\\', '\\\\').replace('"', '\\"')
+    applescript = f'''
+tell application "Things3"
+    activate
+    open location "things:///show?id={project_id}"
+end tell
+delay 0.6
+tell application "System Events"
+    tell process "Things3"
+        click menu item "New Heading" of menu "File" of menu bar 1
+    end tell
+    delay 0.3
+    keystroke "{escaped_title}"
+    delay 0.2
+    key code 36
+end tell
+delay 0.4
+'''
+    subprocess.run(
+        ['osascript', '-e', applescript],
+        check=True, capture_output=True, text=True
+    )
+
+    after = things.tasks(type='heading', project=project_id) or []
+    new_headings = [h for h in after if h['uuid'] not in before and h.get('title') == title]
+    if not new_headings:
+        raise RuntimeError(
+            f"add_heading: UI flow completed but no new heading matching '{title}' "
+            f"was found in project {project_id}. Check Accessibility permission "
+            f"for System Events and that the project ID is valid."
+        )
+    return new_headings[0]['uuid']
+
 def construct_url(command: str, params: Dict[str, Any]) -> str:
     """Construct a Things URL from command and parameters."""
     # Start with base URL

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, Mock
 import subprocess
 from things_mcp.url_scheme import (
-    execute_url, construct_url, add_todo, add_project, add_area,
+    execute_url, construct_url, add_todo, add_project, add_area, add_heading,
     update_todo, update_project, show, search, format_when_with_reminder
 )
 
@@ -77,6 +77,57 @@ class TestAddArea:
 
         script = mock_run.call_args[0][0][2]
         assert 'name:"foo\\\\bar"' in script
+
+
+class TestAddHeading:
+    """Test the add_heading function (UI-scripting based — Things has no native API for headings)."""
+
+    @patch('things_mcp.url_scheme.subprocess.run')
+    @patch('things_mcp.url_scheme.things')
+    def test_add_heading_returns_new_uuid(self, mock_things, mock_run):
+        """add_heading diffs heading lists before/after and returns the new UUID."""
+        mock_things.tasks.side_effect = [
+            [{'uuid': 'OLD1', 'title': 'existing'}],
+            [{'uuid': 'OLD1', 'title': 'existing'}, {'uuid': 'NEW1', 'title': 'clx'}],
+        ]
+        mock_run.return_value = Mock(returncode=0)
+
+        uuid = add_heading('clx', 'PROJECT_ID')
+
+        assert uuid == 'NEW1'
+        mock_run.assert_called_once()
+        script = mock_run.call_args[0][0][2]
+        assert 'things:///show?id=PROJECT_ID' in script
+        assert 'New Heading' in script
+        assert 'keystroke "clx"' in script
+
+    @patch('things_mcp.url_scheme.subprocess.run')
+    @patch('things_mcp.url_scheme.things')
+    def test_add_heading_raises_when_no_new_heading_appears(self, mock_things, mock_run):
+        """If the UI flow fails to produce a matching heading, raise rather than return garbage."""
+        mock_things.tasks.side_effect = [
+            [{'uuid': 'OLD1', 'title': 'existing'}],
+            [{'uuid': 'OLD1', 'title': 'existing'}],
+        ]
+        mock_run.return_value = Mock(returncode=0)
+
+        with pytest.raises(RuntimeError, match="no new heading matching 'clx'"):
+            add_heading('clx', 'PROJECT_ID')
+
+    @patch('things_mcp.url_scheme.subprocess.run')
+    @patch('things_mcp.url_scheme.things')
+    def test_add_heading_escapes_double_quotes(self, mock_things, mock_run):
+        """Titles with double quotes are escaped before being embedded in the keystroke string."""
+        mock_things.tasks.side_effect = [
+            [],
+            [{'uuid': 'X', 'title': 'foo "bar"'}],
+        ]
+        mock_run.return_value = Mock(returncode=0)
+
+        add_heading('foo "bar"', 'PROJECT_ID')
+
+        script = mock_run.call_args[0][0][2]
+        assert 'keystroke "foo \\"bar\\""' in script
 
 
 class TestConstructUrl:

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, Mock
 import subprocess
 from things_mcp.url_scheme import (
-    execute_url, construct_url, add_todo, add_project,
+    execute_url, construct_url, add_todo, add_project, add_area,
     update_todo, update_project, show, search, format_when_with_reminder
 )
 
@@ -35,6 +35,48 @@ class TestExecuteUrl:
 
         assert mock_run.call_count == 2
         mock_run.assert_called_with(['open', '-g', 'things:///add?title=Test'], check=True)
+
+
+class TestAddArea:
+    """Test the add_area function (AppleScript-based since URL scheme has no add-area)."""
+
+    @patch('subprocess.run')
+    def test_add_area_basic(self, mock_run):
+        """Test basic Area creation returns the new UUID."""
+        mock_run.return_value = Mock(stdout="ABC123XYZ\n", returncode=0)
+
+        uuid = add_area("Backlog")
+
+        assert uuid == "ABC123XYZ"
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        assert args[0][0] == 'osascript'
+        assert args[0][1] == '-e'
+        assert 'tell application "Things3"' in args[0][2]
+        assert 'name:"Backlog"' in args[0][2]
+        assert kwargs.get('check') is True
+        assert kwargs.get('capture_output') is True
+        assert kwargs.get('text') is True
+
+    @patch('subprocess.run')
+    def test_add_area_escapes_double_quotes(self, mock_run):
+        """Titles containing double quotes are escaped to prevent AppleScript injection."""
+        mock_run.return_value = Mock(stdout="UUID1\n", returncode=0)
+
+        add_area('Project "Alpha"')
+
+        script = mock_run.call_args[0][0][2]
+        assert 'name:"Project \\"Alpha\\""' in script
+
+    @patch('subprocess.run')
+    def test_add_area_escapes_backslashes(self, mock_run):
+        """Backslashes in titles are escaped before quote escaping."""
+        mock_run.return_value = Mock(stdout="UUID2\n", returncode=0)
+
+        add_area('foo\\bar')
+
+        script = mock_run.call_args[0][0][2]
+        assert 'name:"foo\\\\bar"' in script
 
 
 class TestConstructUrl:


### PR DESCRIPTION
## Summary
Two new MCP tools that close the remaining URL-scheme gaps for organizational structure creation in Things 3:

- **`add-area`** — creates an Area via AppleScript (`make new area`)
- **`add-heading`** — creates a Heading inside an existing Project via System Events UI scripting (File > New Heading)

Both return the new object's UUID for follow-up operations.

## Motivation
The Things URL scheme cannot create either Areas or standalone Headings in an existing Project:
- No `add-area` command exists at all
- The JSON URL scheme's `heading` type is silently ignored when sent into an existing project (it's only honored as a child item of a brand-new project being created in the same call)

This means MCP clients can't fully bootstrap a Things 3 organization (Area + Project + Headings + Todos) in one workflow. Both tools fill that gap.

## Approach

**`add-area`** uses native AppleScript via `osascript`:
```applescript
tell application "Things3"
  set newArea to make new area with properties {name:"…"}
  return id of newArea
end tell
```
This is exposed by Things' AppleScript dictionary on all supported macOS versions.

**`add-heading`** is harder because Things 3 exposes **no** AppleScript class for headings, things.py is read-only, and the JSON URL scheme can't create standalone headings (verified empirically with valid auth-token). So this drives the UI:
1. Navigate to the project via `things:///show?id=…`
2. Click `File > New Heading` via System Events
3. Send the title via `keystroke` and press Return
4. Diff `things.tasks(type='heading', project=…)` before/after to recover the new UUID

Side effects called out in the docstring: requires Accessibility permission and momentarily brings Things 3 to the foreground. Raises `RuntimeError` with actionable guidance if no matching heading appears (rather than returning a stale UUID).

## Security
Both tools escape title strings (backslashes first, then double-quotes) before embedding them in AppleScript. `add-heading` additionally escapes the title before the `keystroke` command.

## Tests
- `TestAddArea` (3): basic creation, double-quote escape, backslash escape
- `TestAddHeading` (3): success path with before/after diff, RuntimeError when no new heading appears, double-quote escape in keystroke

Full test suite: **127 passed** (was 121 on main).

## Use case
I was migrating task data from another system into Things 3 and wanted the full bootstrap (Area → Project → Headings → Todos) scriptable from one MCP session. These two tools close the remaining gaps.