### PR TITLE
Fix URL encoding to escape slashes in parameter values (#47)

### DIFF
--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -63,7 +63,10 @@ def construct_url(command: str, params: Dict[str, Any]) -> str:
             # Handle lists (for tags, checklist items etc)
             elif isinstance(value, list):
                 value = ','.join(str(v) for v in value)
-            encoded_params.append(f"{key}={urllib.parse.quote(str(value))}")
+            # safe='' so '/' inside values (e.g. "2/13" in a title) is percent-encoded
+            # as %2F. urllib.parse.quote's default safe='/' would leave it as a literal
+            # slash, which Things parses as a path delimiter and silently truncates.
+            encoded_params.append(f"{key}={urllib.parse.quote(str(value), safe='')}")
 
         url += "?" + "&".join(encoded_params)
 

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -71,6 +71,13 @@ class TestConstructUrl:
         url = construct_url("add", params)
         assert "tags=work%2Curgent" in url
     
+    def test_construct_url_encodes_slash_in_values(self):
+        """Slashes in parameter values must be percent-encoded (issue #47)."""
+        params = {"title": "Example 2/13 project title"}
+        url = construct_url("update-project", params)
+        assert "title=Example%202%2F13%20project%20title" in url
+        assert "2/13" not in url
+
     @patch('things.token')
     def test_construct_url_auth_token_update(self, mock_token):
         """Test auth token inclusion for update command."""


### PR DESCRIPTION
## Summary

Fixes #47 — updates to a Things item title containing `/` were silently truncated.

`urllib.parse.quote` defaults to `safe='/'`, so `/` inside a query parameter value passed through `construct_url()` was emitted as a literal slash. Things parses that as a URL path delimiter and drops everything after it. Switching to `safe=''` makes the helper encode `/` as `%2F`, matching the encoding produced by `things.url()` from `things-py`.

This is a one-line change in `construct_url`, so it fixes every URL-scheme operation that goes through that helper (add, update, update-project, add-project, show, search) — not just `update-project`, which is where the bug was reported.

## Test plan

- [x] Added regression test `test_construct_url_encodes_slash_in_values` covering "Example 2/13 project title" → expects `%2F`
- [x] Full suite: `uv run --extra test pytest` — 122 passed
- [x] Existing URL-scheme tests still green (none relied on the unescaped-slash behavior)