### PR TITLE
Fix get_today TypeError when overdue items have no start_date (#43)

### DIFF
--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -54,6 +54,37 @@ def _is_in_someday_project(todo, someday_project_ids, heading_to_project):
     return False
 
 
+def _today_fallback():
+    """Re-implementation of ``things.today()`` with a None-safe sort key.
+
+    Workaround for an upstream things-py bug (see things-mcp #43): the
+    library's ``today()`` aggregates three task sets and sorts the union
+    on ``(today_index, start_date)``. The "unconfirmed overdue" branch
+    selects tasks via ``start_date=False`` — i.e. tasks with a deadline
+    today but no start date — so ``start_date`` is None for those rows.
+    Mixed with the other two branches (which have string start_dates),
+    the tuple comparison crashes with
+    ``'<' not supported between instances of 'NoneType' and 'str'``.
+
+    We push None start_dates to the end with a sentinel string.
+    """
+    regular = things.tasks(
+        start_date=True, start="Anytime", index="todayIndex", include_items=True
+    ) or []
+    unconfirmed_scheduled = things.tasks(
+        start_date="past", start="Someday", index="todayIndex", include_items=True
+    ) or []
+    unconfirmed_overdue = things.tasks(
+        start_date=False, deadline="past", deadline_suppressed=False, include_items=True
+    ) or []
+    result = [*regular, *unconfirmed_scheduled, *unconfirmed_overdue]
+    result.sort(key=lambda t: (
+        t["today_index"] if t.get("today_index") is not None else 0,
+        t["start_date"] if t.get("start_date") is not None else "9999-99-99",
+    ))
+    return result
+
+
 # Helper function to filter out tasks from Someday projects
 def filter_someday_project_tasks(todos):
     """Filter out tasks that belong to Someday projects.
@@ -87,7 +118,10 @@ async def get_inbox() -> str:
 @mcp.tool
 async def get_today() -> str:
     """Get todos due today"""
-    todos = things.today(include_items=True)
+    try:
+        todos = things.today(include_items=True)
+    except TypeError:
+        todos = _today_fallback()
     if not todos:
         return "No items found"
     # Filter out tasks from Someday projects

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,5 +1,5 @@
 import pytest
-from things_mcp.server import get_todos, get_today, search_todos, search_advanced
+from things_mcp.server import get_todos, get_today, search_todos, search_advanced, _today_fallback
 
 
 @pytest.mark.asyncio
@@ -24,6 +24,47 @@ async def test_get_today_includes_checklist(mocker, mock_todo):
     assert "Checklist:" in result
     assert "First item" in result
     mock_today.assert_called_once_with(include_items=True)
+
+
+@pytest.mark.asyncio
+async def test_get_today_recovers_from_things_py_sort_typeerror(mocker, mock_todo):
+    """Regression for #43: when things.today() crashes on the upstream
+    None-vs-str sort, get_today should fall back to a local safe aggregation."""
+    mocker.patch(
+        'things.today',
+        side_effect=TypeError("'<' not supported between instances of 'NoneType' and 'str'"),
+    )
+    mock_tasks = mocker.patch('things.tasks')
+    # First call (regular_today_tasks) has a dated task; second (unconfirmed_scheduled)
+    # is empty; third (unconfirmed_overdue) yields a deadline-only task with start_date=None.
+    overdue = {
+        'uuid': 'overdue-uuid',
+        'title': 'Overdue with no start_date',
+        'type': 'to-do',
+        'status': 'open',
+        'today_index': 0,
+        'start_date': None,
+        'deadline': '2026-06-04',
+    }
+    mock_tasks.side_effect = [[mock_todo], [], [overdue]]
+
+    result = await get_today.fn()
+
+    assert "Test Todo" in result
+    assert "Overdue with no start_date" in result
+
+
+def test_today_fallback_sort_handles_none_start_date(mocker):
+    """The fallback must not raise TypeError when start_date is None."""
+    dated = {'uuid': 'a', 'title': 'A', 'today_index': 1, 'start_date': '2026-06-04'}
+    undated = {'uuid': 'b', 'title': 'B', 'today_index': 0, 'start_date': None}
+    mock_tasks = mocker.patch('things.tasks')
+    mock_tasks.side_effect = [[dated], [], [undated]]
+
+    result = _today_fallback()
+
+    # Undated row sorts after the dated one because we push None to the end.
+    assert [r['uuid'] for r in result] == ['b', 'a']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #43 — `get_today` intermittently crashes with `'<' not supported between instances of 'NoneType' and 'str'`.

**Root cause** sits in `things-py`, not in this repo. `things.today()` aggregates three task sets and sorts the union on `(today_index, start_date)`. The third branch is "unconfirmed overdue", selected via `start_date=False` — i.e. tasks with a deadline today and no start date. Those rows have `start_date=None`, and when sorted alongside the other two branches' string dates, the tuple comparison crashes.

The intermittency in the report is exactly the bug's signature: the crash fires only when the overdue branch returns ≥1 row **and** another branch also returns rows. A user with only dated items in Today never hits it.

**Fix** wraps `things.today()` in `try/except TypeError` and falls back to a local re-implementation (`_today_fallback`) that runs the same three `things.tasks()` queries but uses a None-safe sort key — a sentinel `"9999-99-99"` pushes undated rows to the end. The happy path stays untouched, so any future upstream improvements to `things.today()` (e.g. repeating-task support) still flow through.

An upstream PR to `thingsapi/things.py` would let us delete the fallback eventually; I'm happy to open that too if you'd prefer that route.

## Test plan

- [x] Added `test_get_today_recovers_from_things_py_sort_typeerror`: mocks `things.today()` to raise the exact upstream TypeError, mocks `things.tasks()` for the fallback, asserts get_today returns rather than propagating
- [x] Added `test_today_fallback_sort_handles_none_start_date`: feeds the fallback a dated row + an undated row, asserts ordering
- [x] Full suite: `uv run --extra test pytest` — 124 passed