### PR TITLE
Fix get_logbook to filter by completion date (#46)

### DIFF
--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -1,6 +1,8 @@
 from typing import List
 import logging
 import os
+import re
+from datetime import datetime, timedelta
 import things
 from fastmcp import FastMCP
 from .formatters import format_todo, format_project, format_area, format_tag, format_heading
@@ -143,6 +145,29 @@ async def get_someday() -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
+_LOGBOOK_PERIOD_RE = re.compile(r'(\d+)([dwmy])')
+_LOGBOOK_PERIOD_DAYS = {'d': 1, 'w': 7, 'm': 30, 'y': 365}
+
+
+def _parse_logbook_period(period: str):
+    """Return a timedelta for strings like '7d', '2w', '3m', '1y', or None."""
+    match = _LOGBOOK_PERIOD_RE.fullmatch(period.strip().lower())
+    if not match:
+        return None
+    return timedelta(days=int(match.group(1)) * _LOGBOOK_PERIOD_DAYS[match.group(2)])
+
+
+def _stop_datetime(todo):
+    """Parse a todo's stop_date into a naive datetime, or None if absent/unparseable."""
+    stop = todo.get('stop_date')
+    if not stop:
+        return None
+    try:
+        return datetime.fromisoformat(str(stop).replace(' ', 'T'))
+    except ValueError:
+        return None
+
+
 @mcp.tool
 async def get_logbook(period: str = "7d", limit: int = 50) -> str:
     """Get completed todos from Logbook, defaults to last 7 days
@@ -151,9 +176,27 @@ async def get_logbook(period: str = "7d", limit: int = 50) -> str:
         period: Time period to look back (e.g., '3d', '1w', '2m', '1y'). Defaults to '7d'
         limit: Maximum number of entries to return. Defaults to 50
     """
-    todos = things.last(period, status='completed', include_items=True)
-    if todos and len(todos) > limit:
-        todos = todos[:limit]
+    # things.last(period, status='completed') filters on creationDate, not
+    # stopDate — so tasks created before the window but completed inside it
+    # are invisible (which is most tasks in real use). Fetch all completed
+    # tasks and filter on stop_date in Python.
+    delta = _parse_logbook_period(period)
+    if delta is None:
+        return (
+            f"Invalid period {period!r}. Use a number followed by d/w/m/y, "
+            "e.g. '7d', '2w', '3m', '1y'."
+        )
+
+    cutoff = datetime.now() - delta
+    all_completed = things.tasks(status='completed', include_items=True) or []
+    in_window = []
+    for todo in all_completed:
+        stopped = _stop_datetime(todo)
+        if stopped is not None and stopped >= cutoff:
+            in_window.append((stopped, todo))
+    in_window.sort(key=lambda pair: pair[0], reverse=True)
+    todos = [t for _, t in in_window[:limit]]
+
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,5 +1,9 @@
+from datetime import datetime, timedelta
 import pytest
-from things_mcp.server import get_todos, get_today, search_todos, search_advanced
+from things_mcp.server import (
+    get_todos, get_today, search_todos, search_advanced,
+    get_logbook, _parse_logbook_period,
+)
 
 
 @pytest.mark.asyncio
@@ -66,3 +70,93 @@ async def test_search_advanced_without_type(mocker, mock_todo):
         include_items=True, status="incomplete"
     )
     assert "Test Todo" in result
+
+
+# --- get_logbook (#46): filter by stop_date, not creation date ----------------
+
+def _completed(uuid, title, stop_date):
+    return {
+        'uuid': uuid,
+        'title': title,
+        'type': 'to-do',
+        'status': 'completed',
+        'stop_date': stop_date,
+    }
+
+
+def test_parse_logbook_period_accepts_dwmy():
+    assert _parse_logbook_period('7d') == timedelta(days=7)
+    assert _parse_logbook_period('2w') == timedelta(days=14)
+    assert _parse_logbook_period('3m') == timedelta(days=90)
+    assert _parse_logbook_period('1y') == timedelta(days=365)
+
+
+def test_parse_logbook_period_rejects_garbage():
+    assert _parse_logbook_period('') is None
+    assert _parse_logbook_period('week') is None
+    assert _parse_logbook_period('7') is None
+    assert _parse_logbook_period('-3d') is None
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_includes_tasks_completed_in_window_even_if_created_earlier(mocker):
+    """Regression for #46: tasks created long ago but completed recently must appear."""
+    today = datetime.now().date().isoformat()
+    long_ago_completed_recently = _completed('a', 'Old task done today', today)
+    mocker.patch('things.tasks', return_value=[long_ago_completed_recently])
+
+    result = await get_logbook.fn(period='7d')
+
+    assert 'Old task done today' in result
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_excludes_tasks_completed_before_window(mocker):
+    long_ago = (datetime.now() - timedelta(days=60)).date().isoformat()
+    today = datetime.now().date().isoformat()
+    mocker.patch('things.tasks', return_value=[
+        _completed('a', 'Within window', today),
+        _completed('b', 'Outside window', long_ago),
+    ])
+
+    result = await get_logbook.fn(period='7d')
+
+    assert 'Within window' in result
+    assert 'Outside window' not in result
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_sorts_newest_completion_first(mocker):
+    today = datetime.now().date().isoformat()
+    yesterday = (datetime.now() - timedelta(days=1)).date().isoformat()
+    two_days_ago = (datetime.now() - timedelta(days=2)).date().isoformat()
+    mocker.patch('things.tasks', return_value=[
+        _completed('a', 'Two days ago', two_days_ago),
+        _completed('b', 'Today', today),
+        _completed('c', 'Yesterday', yesterday),
+    ])
+
+    result = await get_logbook.fn(period='7d')
+
+    assert result.index('Today') < result.index('Yesterday') < result.index('Two days ago')
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_respects_limit(mocker):
+    today = datetime.now().date().isoformat()
+    mocker.patch('things.tasks', return_value=[
+        _completed(f'u{i}', f'Task {i}', today) for i in range(10)
+    ])
+
+    result = await get_logbook.fn(period='7d', limit=3)
+
+    assert sum(1 for line in result.split('\n') if line.startswith('Title:')) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_logbook_invalid_period(mocker):
+    mocker.patch('things.tasks', return_value=[])
+
+    result = await get_logbook.fn(period='lol')
+
+    assert 'Invalid period' in result


### PR DESCRIPTION
## Summary

Fixes #46 — `get_logbook` was missing most recently-completed tasks.

`things.last(period, status='completed')` filters on `creationDate`, not `stopDate`, so any task created before the period window and checked off recently is invisible. That covers most logbook entries in real use: recurring tasks, templates, long-lived todos. It also explains the secondary symptom in the report where `'7d'` and `'1w'` returned 0 items while `'14d'` returned a few — those were just the tasks that happened to be both created and completed within 14 days.

The fix replaces the upstream call with a Python-level filter:
- fetch all completed tasks via `things.tasks(status='completed', include_items=True)`
- parse the period string (`d`/`w`/`m`/`y`) into a `timedelta`
- keep rows whose `stop_date` is within the window
- sort newest-completion first, then apply the limit

Period parsing now accepts `'m'` (~30d) too, matching what the docstring already advertised. Invalid period strings return an explanatory message rather than crashing.

The underlying fix really belongs in `things-py` (`last()` should filter on `stopDate` when `status='completed'`), but the self-contained workaround here doesn't depend on a library change.

## Test plan

- [x] Added 7 tests: period parsing (dwmy + garbage), in-window inclusion despite old creation date, out-of-window exclusion, sort order, limit, invalid period
- [x] Full suite: `uv run --extra test pytest` — 128 passed