### PR TITLE
Add checklist-item parameters to update_todo (#34)

### DIFF
--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -438,7 +438,10 @@ async def update_todo(
     list: str = None,
     list_id: str = None,
     heading: str = None,
-    heading_id: str = None
+    heading_id: str = None,
+    checklist_items: List[str] = None,
+    prepend_checklist_items: List[str] = None,
+    append_checklist_items: List[str] = None,
 ) -> str:
     """Update an existing todo in Things
 
@@ -456,6 +459,9 @@ async def update_todo(
         list_id: The ID of a project or area to move the to-do into (takes precedence over list)
         heading: The heading title to move the to-do under
         heading_id: The heading ID to move the to-do under (takes precedence over heading)
+        checklist_items: Replace the entire checklist with these items
+        prepend_checklist_items: Add these items to the start of the existing checklist
+        append_checklist_items: Add these items to the end of the existing checklist
     """
     url = url_scheme.update_todo(
         id=id,
@@ -469,7 +475,10 @@ async def update_todo(
         list=list,
         list_id=list_id,
         heading=heading,
-        heading_id=heading_id
+        heading_id=heading_id,
+        checklist_items=checklist_items,
+        prepend_checklist_items=prepend_checklist_items,
+        append_checklist_items=append_checklist_items,
     )
     url_scheme.execute_url(url)
     return f"Updated todo with ID: {id}"

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -152,7 +152,10 @@ def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = Non
                 tags: Optional[list[str]] = None, completed: Optional[bool] = None,
                 canceled: Optional[bool] = None, list: Optional[str] = None,
                 list_id: Optional[str] = None, heading: Optional[str] = None,
-                heading_id: Optional[str] = None) -> str:
+                heading_id: Optional[str] = None,
+                checklist_items: Optional[list[str]] = None,
+                prepend_checklist_items: Optional[list[str]] = None,
+                append_checklist_items: Optional[list[str]] = None) -> str:
     """Construct URL to update an existing todo.
 
     Args:
@@ -171,6 +174,9 @@ def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = Non
         list_id: UUID of project/area to move to (takes precedence over list)
         heading: Heading title to move under
         heading_id: UUID of heading to move under (takes precedence over heading)
+        checklist_items: Replace the entire checklist with these items
+        prepend_checklist_items: Add these items to the start of the checklist
+        append_checklist_items: Add these items to the end of the checklist
     """
     params = {
         'id': id,
@@ -184,7 +190,10 @@ def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = Non
         'list': list,
         'list-id': list_id,
         'heading': heading,
-        'heading-id': heading_id
+        'heading-id': heading_id,
+        'checklist-items': '\n'.join(checklist_items) if checklist_items else None,
+        'prepend-checklist-items': '\n'.join(prepend_checklist_items) if prepend_checklist_items else None,
+        'append-checklist-items': '\n'.join(append_checklist_items) if append_checklist_items else None,
     }
     return construct_url('update', {k: v for k, v in params.items() if v is not None})
 

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -215,6 +215,27 @@ class TestUpdateTodo:
         assert "heading-id=heading-uuid" in url
 
 
+    @patch('things.token')
+    def test_update_todo_replaces_checklist(self, mock_token):
+        """checklist_items replaces the entire checklist via 'checklist-items' param."""
+        mock_token.return_value = "auth-token"
+        url = update_todo(id="todo-123", checklist_items=["Step 1", "Step 2"])
+        # newline join → "Step 1\nStep 2", then URL-encoded to %0A between items
+        assert "checklist-items=Step%201%0AStep%202" in url
+
+    @patch('things.token')
+    def test_update_todo_prepends_checklist(self, mock_token):
+        mock_token.return_value = "auth-token"
+        url = update_todo(id="todo-123", prepend_checklist_items=["New first"])
+        assert "prepend-checklist-items=New%20first" in url
+
+    @patch('things.token')
+    def test_update_todo_appends_checklist(self, mock_token):
+        mock_token.return_value = "auth-token"
+        url = update_todo(id="todo-123", append_checklist_items=["Extra A", "Extra B"])
+        assert "append-checklist-items=Extra%20A%0AExtra%20B" in url
+
+
 class TestUpdateProject:
     """Test the update_project function."""
     


### PR DESCRIPTION
## Summary

Fixes #34 — `update_todo` couldn't touch checklist items, so the only way to alter a checklist was to delete and recreate the entire todo (losing the UUID and other metadata).

Things' URL scheme `update` command already accepts the three checklist parameters; the MCP wrapper just didn't surface them. This patch passes them through:

- `checklist_items` — replace the entire checklist
- `prepend_checklist_items` — add items to the start, preserving existing ones
- `append_checklist_items` — add items to the end

The same encoding as `add_todo`'s `checklist_items`: list of strings joined with `\n`.

## Limitation

The URL scheme doesn't let us toggle individual items' completion state — only the list contents can be edited. The issue described "add, modify, or remove" use cases; this covers add (prepend/append) and remove-and-replace (full `checklist_items`), but not in-place modification of a single item.

## Test plan

- [x] Added 3 tests for replace/prepend/append URL construction
- [x] Full suite: `uv run --extra test pytest` — 124 passed