### PR TITLE
Add tag usage report and incremental tag-add (#14)

### DIFF
--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -247,6 +247,40 @@ async def get_tagged_items(tag: str) -> str:
     return "\n\n---\n\n".join(formatted_todos)
 
 @mcp.tool
+async def get_tag_usage(only_unused: bool = False) -> str:
+    """Report how many items use each tag, sorted by usage (highest first).
+
+    Useful for cleaning up tags that accumulate over time. Identify
+    rarely-used or unused tags first; then either remove them from any
+    remaining items (via update_todo's tags parameter) or delete the
+    tag manually in Things — the URL scheme does not support tag
+    deletion or renaming.
+
+    Args:
+        only_unused: If true, return only tags with zero items.
+    """
+    tags = things.tags()
+    if not tags:
+        return "No tags found"
+
+    rows = []
+    for tag in tags:
+        title = tag['title']
+        open_count = len(things.todos(tag=title) or [])
+        all_count = len(things.tasks(tag=title, status=None) or [])
+        rows.append((title, open_count, all_count))
+
+    if only_unused:
+        rows = [r for r in rows if r[2] == 0]
+        if not rows:
+            return "No unused tags"
+        rows.sort(key=lambda r: r[0].lower())
+    else:
+        rows.sort(key=lambda r: (-r[2], r[0].lower()))
+
+    return "\n".join(f"{name}: {open_c} open, {all_c} total" for name, open_c, all_c in rows)
+
+@mcp.tool
 async def get_headings(project_uuid: str = None) -> str:
     """Get headings from Things
 
@@ -433,6 +467,7 @@ async def update_todo(
     when: str = None,
     deadline: str = None,
     tags: List[str] = None,
+    add_tags: List[str] = None,
     completed: bool = None,
     canceled: bool = None,
     list: str = None,
@@ -449,7 +484,8 @@ async def update_todo(
         when: New schedule (today, tomorrow, evening, anytime, someday, or YYYY-MM-DD).
             Use YYYY-MM-DD@HH:MM format to add a reminder (e.g., 2024-01-15@14:30)
         deadline: New deadline (YYYY-MM-DD)
-        tags: New tags
+        tags: New tags (replaces all existing tags)
+        add_tags: Tags to append without removing existing tags
         completed: Mark as completed
         canceled: Mark as canceled
         list: The title of a project or area to move the to-do into
@@ -464,6 +500,7 @@ async def update_todo(
         when=when,
         deadline=deadline,
         tags=tags,
+        add_tags=add_tags,
         completed=completed,
         canceled=canceled,
         list=list,

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -149,7 +149,9 @@ def add_project(title: str, notes: Optional[str] = None, when: Optional[str] = N
 
 def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = None,
                 when: Optional[str] = None, deadline: Optional[str] = None,
-                tags: Optional[list[str]] = None, completed: Optional[bool] = None,
+                tags: Optional[list[str]] = None,
+                add_tags: Optional[list[str]] = None,
+                completed: Optional[bool] = None,
                 canceled: Optional[bool] = None, list: Optional[str] = None,
                 list_id: Optional[str] = None, heading: Optional[str] = None,
                 heading_id: Optional[str] = None) -> str:
@@ -165,6 +167,7 @@ def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = Non
             - DateTime (adds reminder): "yyyy-mm-dd@HH:MM" (e.g., "2024-01-15@14:30")
         deadline: New deadline (yyyy-mm-dd)
         tags: New tags (replaces existing)
+        add_tags: Tags to append to the existing list (does not remove existing)
         completed: Mark as completed
         canceled: Mark as canceled
         list: Title of project/area to move to
@@ -179,6 +182,7 @@ def update_todo(id: str, title: Optional[str] = None, notes: Optional[str] = Non
         'when': when,
         'deadline': deadline,
         'tags': tags,
+        'add-tags': add_tags,
         'completed': completed,
         'canceled': canceled,
         'list': list,

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,5 +1,7 @@
 import pytest
-from things_mcp.server import get_todos, get_today, search_todos, search_advanced
+from things_mcp.server import (
+    get_todos, get_today, search_todos, search_advanced, get_tag_usage,
+)
 
 
 @pytest.mark.asyncio
@@ -66,3 +68,56 @@ async def test_search_advanced_without_type(mocker, mock_todo):
         include_items=True, status="incomplete"
     )
     assert "Test Todo" in result
+
+
+# --- get_tag_usage (#14) ------------------------------------------------------
+
+def _set_tag_data(mocker, *, tags, open_counts, all_counts):
+    """Wire up things.tags / things.todos / things.tasks for tag-usage tests.
+
+    open_counts and all_counts are dicts keyed by tag title.
+    """
+    mocker.patch('things.tags', return_value=[{'title': t, 'uuid': f'u-{t}'} for t in tags])
+    mocker.patch('things.todos', side_effect=lambda tag, **kw: [0] * open_counts.get(tag, 0))
+    mocker.patch('things.tasks', side_effect=lambda tag, **kw: [0] * all_counts.get(tag, 0))
+
+
+@pytest.mark.asyncio
+async def test_get_tag_usage_sorts_by_total_desc(mocker):
+    _set_tag_data(
+        mocker,
+        tags=['work', 'home', 'shopping'],
+        open_counts={'work': 5, 'home': 2, 'shopping': 0},
+        all_counts={'work': 30, 'home': 10, 'shopping': 0},
+    )
+
+    result = await get_tag_usage.fn()
+
+    lines = result.split('\n')
+    assert lines[0].startswith('work:')
+    assert lines[1].startswith('home:')
+    assert lines[2].startswith('shopping:')
+    assert '5 open, 30 total' in lines[0]
+
+
+@pytest.mark.asyncio
+async def test_get_tag_usage_only_unused(mocker):
+    _set_tag_data(
+        mocker,
+        tags=['work', 'old-tag-1', 'old-tag-2'],
+        open_counts={'work': 5, 'old-tag-1': 0, 'old-tag-2': 0},
+        all_counts={'work': 30, 'old-tag-1': 0, 'old-tag-2': 0},
+    )
+
+    result = await get_tag_usage.fn(only_unused=True)
+
+    assert 'old-tag-1' in result
+    assert 'old-tag-2' in result
+    assert 'work' not in result
+
+
+@pytest.mark.asyncio
+async def test_get_tag_usage_empty(mocker):
+    mocker.patch('things.tags', return_value=[])
+    result = await get_tag_usage.fn()
+    assert result == 'No tags found'

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -215,6 +215,16 @@ class TestUpdateTodo:
         assert "heading-id=heading-uuid" in url
 
 
+    @patch('things.token')
+    def test_update_todo_add_tags_appends(self, mock_token):
+        """add_tags maps to URL scheme 'add-tags' (append, doesn't replace)."""
+        mock_token.return_value = "auth-token"
+        url = update_todo(id="todo-123", add_tags=["new1", "new2"])
+        assert "add-tags=new1%2Cnew2" in url
+        # 'tags=' (without the add- prefix) should not be present when only add_tags is set
+        assert "&tags=" not in url and not url.endswith("tags=new1%2Cnew2")
+
+
 class TestUpdateProject:
     """Test the update_project function."""
     


### PR DESCRIPTION
## Summary

Fixes #14 — tags accumulate over time and there's no built-in way to spot which ones ended up unused.

Two pieces:

1. **`get_tag_usage` tool** — lists every tag with its open and total task counts, sorted by usage descending. The `only_unused` flag narrows the report to tags that no item references anymore (the cleanup candidates). Tag deletion/rename still has to happen manually in Things because the URL scheme doesn't expose those operations — but the report tells you which ones to delete.

2. **`add_tags` parameter on `update_todo`** — maps to the URL scheme's `add-tags` command, which appends without replacing. The existing `tags` parameter still replaces, so callers can pick the semantics.

Together these enable a cleanup flow:
```
get_tag_usage(only_unused=True)   →  list of dead tags
                                  →  user deletes them in Things UI
get_tag_usage()                   →  spot rarely-used ones
update_todo(id=…, tags=[…])       →  re-tag stragglers, then delete
```

## Limitations

- Tag deletion and renaming aren't possible via URL scheme — the report identifies, the user acts.
- `get_tag_usage` does N+1 queries (one per tag) because `things-py` doesn't expose a count primitive. Fine for typical libraries.

## Test plan

- [x] Added 4 tests: usage sort order, `only_unused` filter, empty-tags case, `add_tags` URL construction
- [x] Full suite: `uv run --extra test pytest` — 125 passed