### PR TITLE
Add bulk_update_todos for weekly-review batch ops (#22)

### DIFF
--- a/src/things_mcp/server.py
+++ b/src/things_mcp/server.py
@@ -475,6 +475,87 @@ async def update_todo(
     return f"Updated todo with ID: {id}"
 
 @mcp.tool
+async def bulk_update_todos(
+    ids: List[str],
+    list: str = None,
+    list_id: str = None,
+    tags: List[str] = None,
+    add_tags: List[str] = None,
+    when: str = None,
+    deadline: str = None,
+    heading: str = None,
+    heading_id: str = None,
+    completed: bool = None,
+    canceled: bool = None,
+) -> str:
+    """Apply the same change to many to-dos in a single Things round-trip.
+
+    Use for weekly-review style operations — e.g. "move every grocery item
+    in my inbox to Shopping List", "tag this batch with 'next-quarter'",
+    "complete all of these". One URL invocation replaces N sequential
+    update_todo calls, which makes 20-task moves feel instant instead of
+    taking minutes.
+
+    All non-None parameters apply to every id in 'ids'. For per-item
+    changes use update_todo individually.
+
+    Args:
+        ids: UUIDs of todos to update
+        list: Project/area title to move all into
+        list_id: Project/area UUID to move all into (takes precedence over list)
+        tags: Replace tags on all (existing tags removed)
+        add_tags: Append tags to all (existing tags preserved)
+        when: Reschedule all (today, tomorrow, evening, anytime, someday, or YYYY-MM-DD)
+        deadline: Set deadline on all (YYYY-MM-DD)
+        heading: Move all under this heading title
+        heading_id: Move all under this heading UUID (takes precedence over heading)
+        completed: Mark all completed
+        canceled: Mark all canceled
+    """
+    if not ids:
+        return "No items to update"
+
+    attributes: dict = {}
+    if list_id is not None:
+        attributes['list-id'] = list_id
+    elif list is not None:
+        attributes['list'] = list
+    if tags is not None:
+        attributes['tags'] = tags
+    if add_tags is not None:
+        attributes['add-tags'] = add_tags
+    if when is not None:
+        attributes['when'] = when
+    if deadline is not None:
+        attributes['deadline'] = deadline
+    if heading_id is not None:
+        attributes['heading-id'] = heading_id
+    elif heading is not None:
+        attributes['heading'] = heading
+    if completed is not None:
+        attributes['completed'] = completed
+    if canceled is not None:
+        attributes['canceled'] = canceled
+
+    if not attributes:
+        return "No changes specified — pass at least one attribute (list, tags, when, …)."
+
+    token = things.token()
+    if not token:
+        return (
+            "THINGS_AUTH_TOKEN not configured. Bulk updates require it. "
+            "Enable in Things → Settings → General → Manage."
+        )
+
+    payload = [
+        {"type": "to-do", "operation": "update", "id": uid, "attributes": attributes}
+        for uid in ids
+    ]
+    url = url_scheme.json_command(payload, auth_token=token)
+    url_scheme.execute_url(url)
+    return f"Submitted bulk update for {len(ids)} todos"
+
+@mcp.tool
 async def update_project(
     id: str,
     title: str = None,

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -1,7 +1,8 @@
+import json as _json
 import urllib.parse
 import subprocess
 import things
-from typing import Optional, Dict, Any, Union
+from typing import Optional, Dict, Any, List, Union
 
 # When parameter accepted values:
 # - Keywords: "today", "tomorrow", "evening", "anytime", "someday"
@@ -218,6 +219,23 @@ def update_project(id: str, title: Optional[str] = None, notes: Optional[str] = 
         'canceled': canceled
     }
     return construct_url('update-project', {k: v for k, v in params.items() if v is not None})
+
+def json_command(payload: List[Dict[str, Any]], auth_token: Optional[str] = None) -> str:
+    """Construct a URL for Things' multi-operation 'json' endpoint.
+
+    Each entry in payload follows the shape:
+        {"type": "to-do", "operation": "create" | "update", "id"?: "<uuid>",
+         "attributes": {... using hyphenated attribute names ...}}
+
+    auth-token is required by Things whenever payload contains an 'update'
+    operation; we include it whenever supplied so callers don't have to
+    pre-classify the batch.
+    """
+    parts = [f"data={urllib.parse.quote(_json.dumps(payload), safe='')}"]
+    if auth_token:
+        parts.append(f"auth-token={urllib.parse.quote(auth_token, safe='')}")
+    return "things:///json?" + "&".join(parts)
+
 
 def show(id: str, query: Optional[str] = None, filter_tags: Optional[list[str]] = None) -> str:
     """Construct URL to show a specific item or list."""

--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,5 +1,9 @@
+import json
+import urllib.parse
 import pytest
-from things_mcp.server import get_todos, get_today, search_todos, search_advanced
+from things_mcp.server import (
+    get_todos, get_today, search_todos, search_advanced, bulk_update_todos,
+)
 
 
 @pytest.mark.asyncio
@@ -66,3 +70,81 @@ async def test_search_advanced_without_type(mocker, mock_todo):
         include_items=True, status="incomplete"
     )
     assert "Test Todo" in result
+
+
+# --- bulk_update_todos (#22) --------------------------------------------------
+
+def _captured_json_payload(mock_execute_url):
+    """Pull the json payload out of the URL handed to execute_url."""
+    url = mock_execute_url.call_args[0][0]
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    return json.loads(qs['data'][0])
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_empty_ids(mocker):
+    mocker.patch('things_mcp.server.url_scheme.execute_url')
+    result = await bulk_update_todos.fn(ids=[], list="Shopping")
+    assert "No items to update" in result
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_no_changes(mocker):
+    mocker.patch('things.token', return_value='tok')
+    mocker.patch('things_mcp.server.url_scheme.execute_url')
+    result = await bulk_update_todos.fn(ids=["u1"])
+    assert "No changes specified" in result
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_missing_token(mocker):
+    mocker.patch('things.token', return_value=None)
+    mocker.patch('things_mcp.server.url_scheme.execute_url')
+    result = await bulk_update_todos.fn(ids=["u1"], list="Shopping")
+    assert "THINGS_AUTH_TOKEN" in result
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_moves_many_in_one_call(mocker):
+    mocker.patch('things.token', return_value='tok')
+    mock_exec = mocker.patch('things_mcp.server.url_scheme.execute_url')
+
+    result = await bulk_update_todos.fn(
+        ids=["u1", "u2", "u3"], list_id="shopping-uuid"
+    )
+
+    # Exactly one URL invocation, not N
+    assert mock_exec.call_count == 1
+    assert "3 todos" in result
+    payload = _captured_json_payload(mock_exec)
+    assert len(payload) == 3
+    assert all(p["operation"] == "update" for p in payload)
+    assert [p["id"] for p in payload] == ["u1", "u2", "u3"]
+    assert all(p["attributes"] == {"list-id": "shopping-uuid"} for p in payload)
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_list_id_overrides_list_title(mocker):
+    mocker.patch('things.token', return_value='tok')
+    mock_exec = mocker.patch('things_mcp.server.url_scheme.execute_url')
+
+    await bulk_update_todos.fn(ids=["u1"], list="By Title", list_id="by-uuid")
+
+    payload = _captured_json_payload(mock_exec)
+    assert payload[0]["attributes"] == {"list-id": "by-uuid"}
+    assert "list" not in payload[0]["attributes"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_todos_complete_and_tag(mocker):
+    mocker.patch('things.token', return_value='tok')
+    mock_exec = mocker.patch('things_mcp.server.url_scheme.execute_url')
+
+    await bulk_update_todos.fn(
+        ids=["u1", "u2"], completed=True, add_tags=["reviewed"]
+    )
+
+    payload = _captured_json_payload(mock_exec)
+    for p in payload:
+        assert p["attributes"]["completed"] is True
+        assert p["attributes"]["add-tags"] == ["reviewed"]

--- a/tests/test_url_scheme.py
+++ b/tests/test_url_scheme.py
@@ -1,9 +1,12 @@
+import json
 import pytest
 from unittest.mock import patch, Mock
 import subprocess
+import urllib.parse
 from things_mcp.url_scheme import (
     execute_url, construct_url, add_todo, add_project,
-    update_todo, update_project, show, search, format_when_with_reminder
+    update_todo, update_project, show, search, format_when_with_reminder,
+    json_command,
 )
 
 
@@ -314,3 +317,33 @@ class TestFormatWhenWithReminder:
         when = format_when_with_reminder("2024-06-15", "10:00")
         url = add_todo("Test task", when=when)
         assert "when=2024-06-15%4010%3A00" in url  # @ is %40, : is %3A
+
+
+class TestJsonCommand:
+    """Test the json_command function used for bulk operations."""
+
+    def _decode_data_param(self, url: str):
+        assert url.startswith("things:///json?")
+        parsed = urllib.parse.urlparse(url)
+        qs = urllib.parse.parse_qs(parsed.query)
+        return json.loads(qs['data'][0]), qs
+
+    def test_json_command_includes_auth_token(self):
+        url = json_command([{"type": "to-do", "attributes": {"title": "x"}}], auth_token="abc")
+        _, qs = self._decode_data_param(url)
+        assert qs['auth-token'] == ['abc']
+
+    def test_json_command_skips_token_when_absent(self):
+        url = json_command([{"type": "to-do", "attributes": {"title": "x"}}])
+        assert "auth-token=" not in url
+
+    def test_json_command_serializes_multiple_updates(self):
+        payload = [
+            {"type": "to-do", "operation": "update", "id": "u1",
+             "attributes": {"list-id": "shopping-uuid"}},
+            {"type": "to-do", "operation": "update", "id": "u2",
+             "attributes": {"list-id": "shopping-uuid"}},
+        ]
+        url = json_command(payload, auth_token="t")
+        decoded, _ = self._decode_data_param(url)
+        assert decoded == payload


### PR DESCRIPTION
## Summary

Fixes #22 — moving 20 todos between lists currently means 20 sequential MCP calls, each spawning a `things://update` URL. The reporter measured ~5 minutes for a single weekly review pass.

Things' `json` URL scheme endpoint takes an array of operations and runs them in a single round-trip. This patch wires it up:

- **`url_scheme.json_command(payload, auth_token)`** builds a `things:///json?data=<JSON>&auth-token=<…>` URL with the payload URL-encoded. Tested for token inclusion, multi-update serialization, and missing-token behavior.
- **`bulk_update_todos(ids, …)`** builds an update payload that applies the same attributes (`list` / `list_id`, `tags`, `add_tags`, `when`, `deadline`, `heading` / `heading_id`, `completed`, `canceled`) to every id, then dispatches one URL. Returns a clear error if `THINGS_AUTH_TOKEN` isn't configured (the `json` endpoint requires it for updates), and another if the call has no actual changes to make.

Per-item changes still go through `update_todo`. Bulk creation could follow in a separate PR if there's demand.

## Test plan

- [x] 3 `json_command` tests (token included / skipped, payload roundtrip)
- [x] 6 `bulk_update_todos` tests (empty ids, no changes, missing token, bulk move issues one URL, list_id wins over list, complete+tag combo)
- [x] Full suite: `uv run --extra test pytest` — 130 passed

I didn't pull the reporter's draft attachment — designed the API fresh against the URL-scheme docs and confirmed the deprecated `add-json` → current `json` endpoint switch via Cultured Code's documentation.