### PR TITLE
Prep v0.8.0: deduplicate formatters + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v0.8.0 - 2026-06-04
+
+### Bug fixes
+
+- **URL Encoding**: Slashes in titles/notes/checklist items are now percent-encoded as `%2F`. Previously a title like "Example 2/13" was silently truncated at the slash by Things' URL parser. Affects every URL-scheme operation, not just project updates. ([#47][i47] / [#48][p48])
+- **`get_today` Resilience**: `get_today` no longer crashes with `'<' not supported between instances of 'NoneType' and 'str'` when Things' Today view contains deadline-only overdue items mixed with dated ones. Falls back to a local, None-safe sort when the upstream `things.today()` sort hits this case. ([#43][i43] / [#49][p49])
+- **Logbook Filter**: `get_logbook` now filters by completion date (`stop_date`) instead of creation date. Tasks created weeks ago but checked off recently now appear in the report; `7d` and `1w` periods return useful results. Period parsing accepts `d`/`w`/`m`/`y` and surfaces invalid period strings explicitly. ([#46][i46] / [#50][p50])
+
+### Features
+
+- **Checklist Updates on Existing Todos**: `update_todo` gains `checklist_items`, `prepend_checklist_items`, and `append_checklist_items` parameters. Existing tasks can now have their checklists edited without recreating the task and losing its UUID. ([#34][i34] / [#51][p51])
+- **Tag Usage Report**: New `get_tag_usage` tool lists every tag with its open and total task counts, sorted by usage descending; `only_unused=True` narrows to cleanup candidates. `update_todo` gains an `add_tags` parameter (append) alongside the existing `tags` (replace). ([#14][i14] / [#52][p52])
+- **Bulk Updates**: New `bulk_update_todos` tool applies the same change (`list`, `tags`/`add_tags`, `when`, `deadline`, `heading`, `completed`, `canceled`) to many to-dos in a single Things round-trip via the URL scheme's `json` endpoint. Replaces N sequential calls for weekly-review batch moves. Requires `THINGS_AUTH_TOKEN`. ([#22][i22] / [#53][p53])
+
+### Internal
+
+- **Formatters Refactor**: Centralised the duplicated `things.get`-with-fallback pattern in a new `_lookup_title` helper, and the four-times-duplicated Created/Modified date block in a new `_append_timestamps` helper. Behaviour unchanged — the 67 existing formatter tests all still pass.
+- **Acknowledged Things-API Limits**: Recurrence creation ([#42][i42]) and standalone heading creation ([#10][i10]) cannot be implemented via Things' current URL scheme or AppleScript (`repetition rule` is read-only; headings can only be created inside a project's initial `create` operation). Documented upstream so future contributors don't waste time on the same dead ends.
+
+[i47]: https://github.com/hald/things-mcp/issues/47
+[i43]: https://github.com/hald/things-mcp/issues/43
+[i46]: https://github.com/hald/things-mcp/issues/46
+[i34]: https://github.com/hald/things-mcp/issues/34
+[i14]: https://github.com/hald/things-mcp/issues/14
+[i22]: https://github.com/hald/things-mcp/issues/22
+[i42]: https://github.com/hald/things-mcp/issues/42
+[i10]: https://github.com/hald/things-mcp/issues/10
+[p48]: https://github.com/hald/things-mcp/pull/48
+[p49]: https://github.com/hald/things-mcp/pull/49
+[p50]: https://github.com/hald/things-mcp/pull/50
+[p51]: https://github.com/hald/things-mcp/pull/51
+[p52]: https://github.com/hald/things-mcp/pull/52
+[p53]: https://github.com/hald/things-mcp/pull/53
+
 ## v0.7.3 - 2026-02-13
 
 - **Someday Project Filtering**: Tasks belonging to Someday projects are now filtered out of Today, Upcoming, and Anytime views, matching Things UI behavior. The Someday view also includes tasks from Someday projects that Things.py reports as Anytime. Handles both direct project membership and tasks under headings in Someday projects.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "things-mcp",
   "display_name": "Things MCP",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Model Context Protocol server for Things 3 task management app",
   "long_description": "This extension provides comprehensive task management capabilities through the Things 3 app. It allows you to view, create, update, and search todos, projects, areas, and tags.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-mcp"
-version = "0.7.3"
+version = "0.8.0"
 description = "Things app Model Context Protocol (MCP) server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/things_mcp/formatters.py
+++ b/src/things_mcp/formatters.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+
 def _calculate_age(date_str: str) -> str:
     """Helper function to calculate human-readable age from a date string.
 
@@ -37,23 +38,55 @@ def _calculate_age(date_str: str) -> str:
         years = days // 365
         return f"{years} year{'s' if years > 1 else ''} ago"
 
+
+def _lookup_title(uuid):
+    """Fetch an item by uuid and return its title, or None if missing/broken.
+
+    Wraps the things.get + try/except + None check pattern used to display
+    parent project, area, and heading titles next to a task.
+    """
+    if not uuid:
+        return None
+    try:
+        obj = things.get(uuid)
+    except Exception:
+        return None
+    return obj['title'] if obj and obj.get('title') else None
+
+
+def _append_timestamps(text: str, item: dict) -> str:
+    """Append 'Created/Age' and 'Modified/Last modified' lines if present.
+
+    Both blocks were duplicated across format_todo / format_project /
+    format_area / format_heading with the same try/except shape. Centralise
+    here so the four formatters stay in lock-step.
+    """
+    if item.get('created'):
+        text += f"\nCreated: {item['created']}"
+        try:
+            text += f"\nAge: {_calculate_age(item['created'])}"
+        except (ValueError, TypeError):
+            pass
+    if item.get('modified'):
+        text += f"\nModified: {item['modified']}"
+        try:
+            text += f"\nLast modified: {_calculate_age(item['modified'])}"
+        except (ValueError, TypeError):
+            pass
+    return text
+
+
 def format_todo(todo: dict) -> str:
     """Helper function to format a single todo into a readable string."""
-    logger.debug(f"Formatting todo: {todo}")
     todo_text = f"Title: {todo['title']}"
-
-    # Add UUID for reference
     todo_text += f"\nUUID: {todo['uuid']}"
-
-    # Add type
     todo_text += f"\nType: {todo['type']}"
 
-    # Add status if present
     if todo.get('status'):
         todo_text += f"\nStatus: {todo['status']}"
 
-    # Look up parent project once (used for both List status and Project display)
-    # For heading-level tasks without a project field, resolve heading -> project
+    # Look up parent project once (used for both List status and Project display).
+    # For heading-level tasks without a project field, resolve heading -> project.
     parent_project = None
     if todo.get('project'):
         try:
@@ -68,7 +101,7 @@ def format_todo(todo: dict) -> str:
         except Exception:
             pass
 
-    # Add start/list location with Someday inheritance
+    # Start/list location with Someday inheritance from the parent project.
     if todo.get('start'):
         effective_start = todo['start']
         if effective_start != 'Someday' and parent_project and parent_project.get('start') == 'Someday':
@@ -77,64 +110,32 @@ def format_todo(todo: dict) -> str:
         else:
             todo_text += f"\nList: {effective_start}"
 
-    # Add dates
     if todo.get('start_date'):
         todo_text += f"\nStart Date: {todo['start_date']}"
     if todo.get('deadline'):
         todo_text += f"\nDeadline: {todo['deadline']}"
-    if todo.get('stop_date'):  # Completion date
+    if todo.get('stop_date'):
         todo_text += f"\nCompleted: {todo['stop_date']}"
 
-    # Add creation and modification dates
-    if todo.get('created'):
-        todo_text += f"\nCreated: {todo['created']}"
-        # Calculate age since creation
-        try:
-            age_text = _calculate_age(todo['created'])
-            todo_text += f"\nAge: {age_text}"
-        except (ValueError, TypeError):
-            pass
+    todo_text = _append_timestamps(todo_text, todo)
 
-    if todo.get('modified'):
-        todo_text += f"\nModified: {todo['modified']}"
-        # Calculate time since last modification
-        try:
-            modified_age = _calculate_age(todo['modified'])
-            todo_text += f"\nLast modified: {modified_age}"
-        except (ValueError, TypeError):
-            pass
-
-    # Add notes if present
     if todo.get('notes'):
         todo_text += f"\nNotes: {todo['notes']}"
 
-    # Add project info if present
     if parent_project:
         todo_text += f"\nProject: {parent_project['title']}"
 
-    # Add heading info if present
-    if todo.get('heading'):
-        try:
-            heading = things.get(todo['heading'])
-            if heading:
-                todo_text += f"\nHeading: {heading['title']}"
-        except Exception:
-            pass
+    heading_title = _lookup_title(todo.get('heading'))
+    if heading_title:
+        todo_text += f"\nHeading: {heading_title}"
 
-    # Add area info if present
-    if todo.get('area'):
-        try:
-            area = things.get(todo['area'])
-            if area:
-                todo_text += f"\nArea: {area['title']}"
-        except Exception:
-            pass
+    area_title = _lookup_title(todo.get('area'))
+    if area_title:
+        todo_text += f"\nArea: {area_title}"
 
-    # Add tags if present
     if todo.get('tags'):
         todo_text += f"\nTags: {', '.join(todo['tags'])}"
 
-    # Add checklist if present and contains items
     if isinstance(todo.get('checklist'), list):
         todo_text += "\nChecklist:"
         for item in todo['checklist']:
@@ -143,41 +144,21 @@ def format_todo(todo: dict) -> str:
 
     return todo_text
 
+
 def format_project(project: dict, include_items: bool = False) -> str:
     """Helper function to format a single project."""
     project_text = f"Title: {project['title']}\nUUID: {project['uuid']}"
 
-    if project.get('area'):
-        try:
-            area = things.get(project['area'])
-            if area:
-                project_text += f"\nArea: {area['title']}"
-        except Exception:
-            pass
+    area_title = _lookup_title(project.get('area'))
+    if area_title:
+        project_text += f"\nArea: {area_title}"
 
     if project.get('notes'):
         project_text += f"\nNotes: {project['notes']}"
 
-    # Add creation and modification dates
-    if project.get('created'):
-        project_text += f"\nCreated: {project['created']}"
-        # Calculate age since creation
-        try:
-            age_text = _calculate_age(project['created'])
-            project_text += f"\nAge: {age_text}"
-        except (ValueError, TypeError):
-            pass
+    project_text = _append_timestamps(project_text, project)
 
-    if project.get('modified'):
-        project_text += f"\nModified: {project['modified']}"
-        # Calculate time since last modification
-        try:
-            modified_age = _calculate_age(project['modified'])
-            project_text += f"\nLast modified: {modified_age}"
-        except (ValueError, TypeError):
-            pass
-
-    # Always show headings for projects
+    # Always show headings for projects.
     headings = things.tasks(type='heading', project=project['uuid'])
     if headings:
         project_text += "\n\nHeadings:"
@@ -193,6 +174,7 @@ def format_project(project: dict, include_items: bool = False) -> str:
 
     return project_text
 
+
 def format_area(area: dict, include_items: bool = False) -> str:
     """Helper function to format a single area."""
     area_text = f"Title: {area['title']}\nUUID: {area['uuid']}"
@@ -200,22 +182,7 @@ def format_area(area: dict, include_items: bool = False) -> str:
     if area.get('notes'):
         area_text += f"\nNotes: {area['notes']}"
 
-    # Add creation and modification dates
-    if area.get('created'):
-        area_text += f"\nCreated: {area['created']}"
-        try:
-            age_text = _calculate_age(area['created'])
-            area_text += f"\nAge: {age_text}"
-        except (ValueError, TypeError):
-            pass
-
-    if area.get('modified'):
-        area_text += f"\nModified: {area['modified']}"
-        try:
-            modified_age = _calculate_age(area['modified'])
-            area_text += f"\nLast modified: {modified_age}"
-        except (ValueError, TypeError):
-            pass
+    area_text = _append_timestamps(area_text, area)
 
     if include_items:
         projects = things.projects(area=area['uuid'])
@@ -231,6 +198,7 @@ def format_area(area: dict, include_items: bool = False) -> str:
                 area_text += f"\n- {todo['title']}"
 
     return area_text
+
 
 def format_tag(tag: dict, include_items: bool = False) -> str:
     """Helper function to format a single tag."""
@@ -248,45 +216,25 @@ def format_tag(tag: dict, include_items: bool = False) -> str:
 
     return tag_text
 
+
 def format_heading(heading: dict, include_items: bool = False) -> str:
     """Helper function to format a single heading."""
     heading_text = f"Title: {heading['title']}\nUUID: {heading['uuid']}"
     heading_text += f"\nType: heading"
 
-    # Add project info if present
     if heading.get('project'):
-        if heading.get('project_title'):
-            heading_text += f"\nProject: {heading['project_title']}"
-        else:
-            try:
-                project = things.get(heading['project'])
-                if project:
-                    heading_text += f"\nProject: {project['title']}"
-            except Exception:
-                pass
+        # Prefer the inlined project_title if things-py already provided it,
+        # otherwise fall back to a fresh lookup.
+        project_title = heading.get('project_title') or _lookup_title(heading.get('project'))
+        if project_title:
+            heading_text += f"\nProject: {project_title}"
 
-    # Add dates
-    if heading.get('created'):
-        heading_text += f"\nCreated: {heading['created']}"
-        try:
-            age_text = _calculate_age(heading['created'])
-            heading_text += f"\nAge: {age_text}"
-        except (ValueError, TypeError):
-            pass
-    if heading.get('modified'):
-        heading_text += f"\nModified: {heading['modified']}"
-        try:
-            modified_age = _calculate_age(heading['modified'])
-            heading_text += f"\nLast modified: {modified_age}"
-        except (ValueError, TypeError):
-            pass
+    heading_text = _append_timestamps(heading_text, heading)
 
-    # Add notes if present
     if heading.get('notes'):
         heading_text += f"\nNotes: {heading['notes']}"
 
     if include_items:
-        # Get todos under this heading
         todos = things.todos(heading=heading['uuid'])
         if todos:
             heading_text += "\n\nTasks under heading:"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,7 +1,60 @@
 import pytest
 from unittest.mock import patch
 from datetime import datetime, timedelta
-from things_mcp.formatters import format_todo, format_project, format_area, format_tag, format_heading, _calculate_age
+from things_mcp.formatters import (
+    format_todo, format_project, format_area, format_tag, format_heading,
+    _calculate_age, _lookup_title, _append_timestamps,
+)
+
+
+class TestLookupTitle:
+    """The helper that wraps things.get + try/except + None check."""
+
+    def test_returns_none_for_falsy_uuid(self):
+        assert _lookup_title(None) is None
+        assert _lookup_title("") is None
+
+    @patch('things.get')
+    def test_returns_title_on_hit(self, mock_get):
+        mock_get.return_value = {'title': 'My Area', 'uuid': 'a-1'}
+        assert _lookup_title('a-1') == 'My Area'
+
+    @patch('things.get')
+    def test_returns_none_on_miss(self, mock_get):
+        mock_get.return_value = None
+        assert _lookup_title('missing') is None
+
+    @patch('things.get')
+    def test_returns_none_when_things_get_raises(self, mock_get):
+        mock_get.side_effect = RuntimeError("db locked")
+        assert _lookup_title('a-1') is None
+
+    @patch('things.get')
+    def test_returns_none_when_title_missing(self, mock_get):
+        mock_get.return_value = {'uuid': 'a-1'}  # no 'title' key
+        assert _lookup_title('a-1') is None
+
+
+class TestAppendTimestamps:
+    """The helper that emits Created/Age and Modified/Last modified."""
+
+    def test_skips_when_neither_present(self):
+        assert _append_timestamps("base", {}) == "base"
+
+    def test_emits_created_only(self):
+        now = datetime.now().isoformat()
+        result = _append_timestamps("base", {'created': now})
+        assert "Created:" in result
+        assert "Age: today" in result
+        assert "Modified:" not in result
+
+    def test_swallows_invalid_dates(self):
+        result = _append_timestamps("base", {'created': 'not-a-date', 'modified': 'also-bad'})
+        # Raw values still echoed; age lines suppressed instead of raising.
+        assert "Created: not-a-date" in result
+        assert "Modified: also-bad" in result
+        assert "Age:" not in result
+        assert "Last modified:" not in result
 
 
 class TestCalculateAge:

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "0.7.3"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Release-prep PR that:

1. **Deduplicates `formatters.py`** — extracts two helpers that were copy-pasted across the four formatters.
2. **Bumps version to 0.8.0** in `pyproject.toml`, `manifest.json`, `uv.lock`.
3. **Drafts a v0.8.0 CHANGELOG entry** that covers this cleanup plus the six in-flight PRs (#48–#53) and acknowledges the two upstream-limited won't-fix issues (#42, #10).

## Cleanup details

\`format_todo\`, \`format_project\`, \`format_area\`, and \`format_heading\` all duplicated:

- A \`things.get(uuid)\` + \`try/except Exception\` + \`if obj\` block to resolve parent project / area / heading titles (4 copies).
- A Created/Age + Modified/Last-modified block built on top of \`_calculate_age\` with the same try/except shape (4 copies).

Replaced with:

- \`_lookup_title(uuid) -> Optional[str]\` — uuid → title-or-None, swallowing missing rows and lookup failures.
- \`_append_timestamps(text, item) -> str\` — appends both timestamp lines if the fields are present, suppressing age lines on unparseable dates.

Also drops a \`logger.debug(f\"Formatting todo: {todo}\")\` line that printed the full dict on every format call.

\`formatters.py\`: 296 → 232 lines, 8 new helper tests.

## Dependency on other PRs

The CHANGELOG entry presumes #48–#53 will land before v0.8.0 ships. If any of them won't merge, drop the matching bullet before tagging. No code in this PR depends on those branches, so this one can merge first or last.

## Test plan

- [x] Full suite: \`uv run --extra test pytest\` — **129 passed**
- [x] The 67 existing formatter tests cover all four formatters' code paths and still pass unchanged (behaviour preservation)
- [x] 8 new tests for \`_lookup_title\` (None uuid, hit, miss, exception, missing-title field) and \`_append_timestamps\` (no fields, created-only, invalid dates)